### PR TITLE
Multilingual Atacama Server with Language Routing

### DIFF
--- a/config/languages.toml
+++ b/config/languages.toml
@@ -1,0 +1,38 @@
+# Language configuration for Atacama
+# Defines supported languages and their subdomain mappings
+
+[languages]
+  # Lithuanian language configuration
+  [languages.lithuanian]
+    name = "Lithuanian"
+    code = "lt"
+    subdomains = ["lt"]
+    audio_dir_name = "lithuanian"
+    character_set = "aąbcčdeęėfghiįyjklmnoprsštuųūvzž"
+
+  # Chinese language configuration
+  [languages.chinese]
+    name = "Chinese"
+    code = "zh"
+    subdomains = ["zh", "cn"]
+    audio_dir_name = "chinese"
+    character_set = ""  # Will support all unicode characters for Chinese
+
+  # Korean language configuration
+  [languages.korean]
+    name = "Korean"
+    code = "ko"
+    subdomains = ["ko", "kr"]
+    audio_dir_name = "korean"
+    character_set = ""  # Will support all unicode characters for Korean
+
+  # French language configuration
+  [languages.french]
+    name = "French"
+    code = "fr"
+    subdomains = ["fr"]
+    audio_dir_name = "french"
+    character_set = "aàâäbcçdeéèêëfghiîïjklmnoôöpqrstuùûüvwxyz"
+
+[defaults]
+  default_language = "lithuanian"

--- a/src/common/config/language_config.py
+++ b/src/common/config/language_config.py
@@ -1,0 +1,182 @@
+"""Language configuration management for Atacama."""
+
+import os
+from pathlib import Path
+import tomli
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import constants
+from common.base.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+@dataclass
+class LanguageConfig:
+    """Language configuration data structure."""
+    name: str
+    code: str
+    subdomains: List[str]
+    audio_dir_name: str
+    character_set: str = ""
+
+    def get_audio_dir(self) -> str:
+        """
+        Get the audio directory path for this language.
+
+        :return: Path to the language's audio directory
+        """
+        base_dir = constants.get_trakaido_audio_base_dir()
+        return os.path.join(base_dir, self.audio_dir_name)
+
+class LanguageManager:
+    """Manages language configuration and validation."""
+
+    def __init__(self, config_path: str):
+        """
+        Initialize language manager with configuration file.
+
+        :param config_path: Path to TOML configuration file
+        """
+        self.config_path = config_path
+        self.languages: Dict[str, LanguageConfig] = {}
+        self.subdomain_to_language: Dict[str, str] = {}  # Maps subdomains to language codes
+        self.default_language = "lithuanian"
+        self._load_config()
+
+    def _load_config(self) -> None:
+        """Load and validate language configuration from TOML file."""
+        try:
+            logger.info(f"Loading language configuration from {self.config_path}")
+            with open(self.config_path, 'rb') as f:
+                config = tomli.load(f)
+
+            # Load default language
+            defaults = config.get('defaults', {})
+            self.default_language = defaults.get('default_language', 'lithuanian')
+
+            # Load language configurations
+            languages_config = config.get('languages', {})
+            for language_key, settings in languages_config.items():
+                self.languages[language_key] = LanguageConfig(
+                    name=settings.get('name', language_key),
+                    code=settings.get('code', language_key),
+                    subdomains=settings.get('subdomains', []),
+                    audio_dir_name=settings.get('audio_dir_name', language_key),
+                    character_set=settings.get('character_set', '')
+                )
+
+                # Map each subdomain to this language
+                for subdomain in settings.get('subdomains', []):
+                    if subdomain in self.subdomain_to_language:
+                        # Found duplicate subdomain
+                        existing_language = self.subdomain_to_language[subdomain]
+                        logger.error(f"Duplicate subdomain '{subdomain}' found in languages '{language_key}' and '{existing_language}'")
+                        raise ValueError(f"Duplicate subdomain '{subdomain}' in multiple language configurations")
+                    self.subdomain_to_language[subdomain] = language_key
+
+            # Validate configuration
+            self._validate_config()
+
+            # Log successful initialization
+            logger.info(f"Language configuration loaded successfully: {len(self.languages)} languages")
+            for language_key, config in self.languages.items():
+                logger.info(f"  Language '{language_key}': {config.name} ({config.code}), subdomains: {', '.join(config.subdomains)}")
+
+        except Exception as e:
+            logger.error(f"Error loading language configuration: {str(e)}")
+            raise
+
+    def _validate_config(self) -> None:
+        """Validate language configuration for consistency."""
+        if not self.languages:
+            raise ValueError("No languages defined in configuration")
+
+        if self.default_language not in self.languages:
+            raise ValueError(f"Default language '{self.default_language}' not found in language list")
+
+    def get_language_from_host(self, host: str) -> str:
+        """
+        Get language key for a host name based on subdomain.
+
+        :param host: Host name from request
+        :return: Language key from config, or default if not found
+        """
+        # Strip port from host if present
+        if ':' in host:
+            host = host.split(':', 1)[0]
+
+        # Extract subdomain
+        # Expected format: zh.example.com, fr.example.com, etc.
+        parts = host.split('.')
+        if len(parts) > 2:  # Has subdomain
+            potential_subdomain = parts[0]
+            if potential_subdomain in self.subdomain_to_language:
+                language_key = self.subdomain_to_language[potential_subdomain]
+                logger.debug(f"Subdomain match found: {potential_subdomain} -> {language_key}")
+                return language_key
+
+        # Fall back to default
+        if host != "localhost" and len(parts) > 1:
+            logger.debug(f"No language subdomain found for host: {host}, using default language")
+        return self.default_language
+
+    def get_language_config(self, language_key: str) -> LanguageConfig:
+        """
+        Get configuration for a language.
+
+        :param language_key: Language key to get config for
+        :return: Language configuration or default if not found
+        """
+        if language_key not in self.languages:
+            logger.warning(f"Requested language '{language_key}' not found, using default")
+            return self.languages[self.default_language]
+        return self.languages[language_key]
+
+    def get_all_language_keys(self) -> List[str]:
+        """
+        Get list of all configured language keys.
+
+        :return: List of language keys
+        """
+        return list(self.languages.keys())
+
+    def get_all_languages(self) -> Dict[str, LanguageConfig]:
+        """
+        Get all language configurations.
+
+        :return: Dictionary of language configurations
+        """
+        return self.languages
+
+# Default configuration file path
+DEFAULT_CONFIG_PATH = Path(constants.CONFIG_DIR) / "languages.toml"
+
+# Global language manager instance
+_language_manager = None
+
+def init_language_manager(config_path: Optional[str] = None) -> LanguageManager:
+    """
+    Initialize global language manager instance.
+
+    :param config_path: Path to language configuration file
+    :return: Language manager instance
+    """
+    global _language_manager
+    config_path = config_path or DEFAULT_CONFIG_PATH
+    logger.info(f"Initializing language manager with config path: {config_path}")
+    _language_manager = LanguageManager(config_path)
+    return _language_manager
+
+def get_language_manager() -> LanguageManager:
+    """
+    Get global language manager instance.
+
+    :return: Language manager instance
+    :raises: RuntimeError if manager not initialized
+    """
+    global _language_manager
+    if _language_manager is None:
+        logger.info("Language manager not initialized, initializing with default config")
+        _language_manager = LanguageManager(DEFAULT_CONFIG_PATH)
+    return _language_manager

--- a/src/constants.py
+++ b/src/constants.py
@@ -49,18 +49,42 @@ DATA_DIR = os.path.join(PROJECT_ROOT, "data")
 REACT_COMPILER_JS_DIR = os.path.join(SRC_DIR, 'react_compiler', "js")
 
 # Audio directories
-_PROD_LITHUANIAN_AUDIO_DIR = '/home/atacama/trakaido/'
+_PROD_TRAKAIDO_AUDIO_BASE_DIR = '/home/atacama/trakaido/'
+_DEV_TRAKAIDO_AUDIO_BASE_DIR = '/Users/powera/repo/trakaido/audio/'
+
+# Legacy paths for backward compatibility
+_PROD_LITHUANIAN_AUDIO_DIR = '/home/atacama/trakaido/lithuanian/'
 _DEV_LITHUANIAN_AUDIO_DIR = '/Users/powera/repo/trakaido/audio/lithuanian-audio-cache'
+
+def get_trakaido_audio_base_dir() -> str:
+    """
+    Get the base Trakaido audio directory for all languages.
+
+    :return: Path to the base audio directory
+    """
+    if is_development_mode():
+        return _DEV_TRAKAIDO_AUDIO_BASE_DIR
+    return _PROD_TRAKAIDO_AUDIO_BASE_DIR
 
 def get_lithuanian_audio_dir() -> str:
     """
     Get the Lithuanian audio directory based on the current environment.
-    
+
     :return: Path to the Lithuanian audio directory
     """
     if is_development_mode():
         return _DEV_LITHUANIAN_AUDIO_DIR
     return _PROD_LITHUANIAN_AUDIO_DIR
+
+def get_language_audio_dir(language_audio_dir_name: str) -> str:
+    """
+    Get the audio directory for a specific language.
+
+    :param language_audio_dir_name: The language's audio directory name
+    :return: Path to the language's audio directory
+    """
+    base_dir = get_trakaido_audio_base_dir()
+    return os.path.join(base_dir, language_audio_dir_name)
 
 # Dynamic audio directory based on environment
 LITHUANIAN_AUDIO_DIR = get_lithuanian_audio_dir()

--- a/src/web/blueprints/trakaido/audio.py
+++ b/src/web/blueprints/trakaido/audio.py
@@ -1,4 +1,4 @@
-"""Audio API handlers for Lithuanian language learning."""
+"""Audio API handlers for multi-language learning."""
 
 # Standard library imports
 import os
@@ -6,10 +6,11 @@ import random
 from typing import List, Optional, Union
 
 # Third-party imports
-from flask import Response, abort, jsonify, request, send_file
+from flask import Response, abort, g, jsonify, request, send_file
 
 # Local application imports
 import constants
+from common.config.language_config import get_language_manager
 from .shared import LITHUANIAN_CHARS, logger, sanitize_lithuanian_word, trakaido_bp
 
 
@@ -17,58 +18,97 @@ from .shared import LITHUANIAN_CHARS, logger, sanitize_lithuanian_word, trakaido
 
 # API Documentation for audio endpoints
 AUDIO_API_DOCS = {
-    "GET /api/lithuanian/audio/voices": "List all available voices",
-    "GET /api/lithuanian/audio/{word}": "Get audio for a Lithuanian word (param: voice)"
+    "GET /api/audio/voices": "List all available voices for current language (subdomain)",
+    "GET /api/audio/{word}": "Get audio for a word in current language (subdomain) (param: voice)",
+    "GET /api/lithuanian/audio/voices": "List all available voices for Lithuanian (legacy)",
+    "GET /api/lithuanian/audio/{word}": "Get audio for a Lithuanian word (param: voice) (legacy)",
+    "GET /api/{language}/audio/voices": "List all available voices for specific language",
+    "GET /api/{language}/audio/{word}": "Get audio for a word in specific language (param: voice)"
 }
 
-def get_available_voices() -> List[str]:
+def get_available_voices(audio_dir: Optional[str] = None) -> List[str]:
     """
-    Get a list of available voice directories.
-    
+    Get a list of available voice directories for a language.
+
+    :param audio_dir: Optional audio directory path, defaults to current language's directory
     :return: List of voice names (directory names)
     """
     try:
-        if not os.path.exists(constants.LITHUANIAN_AUDIO_DIR):
-            logger.error(f"Lithuanian audio directory not found: {constants.LITHUANIAN_AUDIO_DIR}")
+        # Use provided directory or fall back to current language's directory
+        if audio_dir is None:
+            if hasattr(g, 'language_config'):
+                audio_dir = g.language_config.get_audio_dir()
+            else:
+                audio_dir = constants.LITHUANIAN_AUDIO_DIR
+
+        if not os.path.exists(audio_dir):
+            logger.error(f"Audio directory not found: {audio_dir}")
             return []
-        
-        # Get all directories in the Lithuanian audio directory
-        voices = [d for d in os.listdir(constants.LITHUANIAN_AUDIO_DIR) 
-                 if os.path.isdir(os.path.join(constants.LITHUANIAN_AUDIO_DIR, d))]
-        
+
+        # Get all directories in the audio directory
+        voices = [d for d in os.listdir(audio_dir)
+                 if os.path.isdir(os.path.join(audio_dir, d))]
+
         return voices
     except Exception as e:
-        logger.error(f"Error getting Lithuanian voice directories: {str(e)}")
+        logger.error(f"Error getting voice directories from {audio_dir}: {str(e)}")
         return []
 
 
-def get_audio_file_path(word: str, voice: Optional[str] = None) -> Optional[str]:
+def sanitize_word_for_audio(word: str, character_set: Optional[str] = None) -> str:
+    """
+    Sanitize a word for use in audio file names.
+
+    :param word: Word to sanitize
+    :param character_set: Optional character set for the language, if None all chars are allowed
+    :return: Sanitized word suitable for filename
+    """
+    if character_set:
+        # If character set is provided, use the existing sanitize_lithuanian_word logic
+        return sanitize_lithuanian_word(word, character_set)
+    else:
+        # For languages without character sets (Chinese, Korean), just remove slashes and nulls
+        return word.replace('/', '').replace('\0', '').lower()
+
+
+def get_audio_file_path(word: str, voice: Optional[str] = None, audio_dir: Optional[str] = None, character_set: Optional[str] = None) -> Optional[str]:
     """
     Get the path to an audio file for the given word and voice.
-    
-    :param word: Lithuanian word to get audio for
+
+    :param word: Word to get audio for
     :param voice: Optional voice name to use, if None a random voice will be selected
+    :param audio_dir: Optional audio directory path, defaults to current language's directory
+    :param character_set: Optional character set for sanitization
     :return: Path to the audio file or None if not found
     """
     try:
-        voices = get_available_voices()
+        # Use provided directory or fall back to current language's directory
+        if audio_dir is None:
+            if hasattr(g, 'language_config'):
+                audio_dir = g.language_config.get_audio_dir()
+                character_set = g.language_config.character_set if character_set is None else character_set
+            else:
+                audio_dir = constants.LITHUANIAN_AUDIO_DIR
+                character_set = LITHUANIAN_CHARS if character_set is None else character_set
+
+        voices = get_available_voices(audio_dir)
         if not voices:
-            logger.error("No Lithuanian voice directories found")
+            logger.error(f"No voice directories found in {audio_dir}")
             return None
-        
+
         # If no voice specified, choose a random one
         selected_voice = voice if voice in voices else random.choice(voices)
-        
-        word_filename = sanitize_lithuanian_word(word)
+
+        word_filename = sanitize_word_for_audio(word, character_set)
 
         # Construct the file path
-        file_path = os.path.join(constants.LITHUANIAN_AUDIO_DIR, selected_voice, f"{word_filename}.mp3")
-        
+        file_path = os.path.join(audio_dir, selected_voice, f"{word_filename}.mp3")
+
         # Check if the file exists
         if not os.path.exists(file_path):
             logger.error(f"Audio file not found: {file_path}")
             return None
-        
+
         return file_path
     except Exception as e:
         logger.error(f"Error getting audio file path for word '{word}': {str(e)}")
@@ -76,40 +116,95 @@ def get_audio_file_path(word: str, voice: Optional[str] = None) -> Optional[str]
 
 
 # API Routes for audio
-@trakaido_bp.route('/api/lithuanian/audio/voices')
-def list_voices() -> Union[Response, tuple]:
+
+# Generic audio endpoints (use current language from subdomain)
+@trakaido_bp.route('/api/audio/voices')
+def list_voices_current() -> Union[Response, tuple]:
     """
-    List all available Lithuanian voices.
-    
+    List all available voices for the current language (determined by subdomain).
+
     :return: JSON response with list of voices
     """
     try:
         voices = get_available_voices()
-        return jsonify({"voices": voices})
+        language_name = g.language_config.name if hasattr(g, 'language_config') else "Lithuanian"
+        return jsonify({"voices": voices, "language": language_name})
     except Exception as e:
-        logger.error(f"Error listing Lithuanian voices: {str(e)}")
+        logger.error(f"Error listing voices for current language: {str(e)}")
         return jsonify({"error": str(e)}), 500
 
 
-@trakaido_bp.route('/api/lithuanian/audio/<word>')
-def serve_lithuanian_audio(word: str) -> Union[Response, tuple]:
+@trakaido_bp.route('/api/audio/<word>')
+def serve_audio_current(word: str) -> Union[Response, tuple]:
     """
-    Serve a Lithuanian audio file for the given word.
-    
-    :param word: Lithuanian word to get audio for
+    Serve an audio file for the given word in the current language (determined by subdomain).
+
+    :param word: Word to get audio for
     :return: Audio file response or error
     """
     try:
         # Get the voice parameter from the request, if provided
         voice = request.args.get('voice')
-        
-        # Get the audio file path
+
+        # Get the audio file path using current language
         file_path = get_audio_file_path(word, voice)
         if not file_path:
-            return abort(404, f"Audio for '{word}' not found")
-        
+            language_name = g.language_config.name if hasattr(g, 'language_config') else "Lithuanian"
+            return abort(404, f"Audio for '{word}' not found in {language_name}")
+
         # Serve the audio file
         return send_file(file_path, mimetype='audio/mpeg')
     except Exception as e:
-        logger.error(f"Error serving Lithuanian audio for word '{word}': {str(e)}")
+        logger.error(f"Error serving audio for word '{word}' in current language: {str(e)}")
+        return jsonify({"error": str(e)}), 500
+
+
+# Language-specific audio endpoints
+@trakaido_bp.route('/api/<language>/audio/voices')
+def list_voices_language(language: str) -> Union[Response, tuple]:
+    """
+    List all available voices for a specific language.
+
+    :param language: Language key (e.g., 'lithuanian', 'chinese', 'korean', 'french')
+    :return: JSON response with list of voices
+    """
+    try:
+        language_manager = get_language_manager()
+        language_config = language_manager.get_language_config(language)
+        audio_dir = language_config.get_audio_dir()
+
+        voices = get_available_voices(audio_dir)
+        return jsonify({"voices": voices, "language": language_config.name})
+    except Exception as e:
+        logger.error(f"Error listing voices for language '{language}': {str(e)}")
+        return jsonify({"error": str(e)}), 500
+
+
+@trakaido_bp.route('/api/<language>/audio/<word>')
+def serve_audio_language(language: str, word: str) -> Union[Response, tuple]:
+    """
+    Serve an audio file for the given word in a specific language.
+
+    :param language: Language key (e.g., 'lithuanian', 'chinese', 'korean', 'french')
+    :param word: Word to get audio for
+    :return: Audio file response or error
+    """
+    try:
+        # Get the voice parameter from the request, if provided
+        voice = request.args.get('voice')
+
+        language_manager = get_language_manager()
+        language_config = language_manager.get_language_config(language)
+        audio_dir = language_config.get_audio_dir()
+        character_set = language_config.character_set
+
+        # Get the audio file path for the specific language
+        file_path = get_audio_file_path(word, voice, audio_dir, character_set)
+        if not file_path:
+            return abort(404, f"Audio for '{word}' not found in {language_config.name}")
+
+        # Serve the audio file
+        return send_file(file_path, mimetype='audio/mpeg')
+    except Exception as e:
+        logger.error(f"Error serving audio for word '{word}' in language '{language}': {str(e)}")
         return jsonify({"error": str(e)}), 500

--- a/src/web/blueprints/trakaido/shared.py
+++ b/src/web/blueprints/trakaido/shared.py
@@ -75,27 +75,31 @@ def trakaido_json(filename: str) -> Response:
         return Response("File not found", status=404)
 
 
-def sanitize_lithuanian_word(word: str) -> str:
+def sanitize_lithuanian_word(word: str, character_set: Optional[str] = None) -> str:
     """
-    Sanitize a Lithuanian word or phrase for use as a filename.
-    
+    Sanitize a word or phrase for use as a filename.
+
     Args:
-        word: The Lithuanian word or phrase to sanitize
-    
+        word: The word or phrase to sanitize
+        character_set: Optional character set to allow, defaults to Lithuanian characters
+
     Returns:
         Sanitized filename-safe version or empty string if invalid
     """
     word = word.strip().lower()
-    
+
     # Replace spaces with underscores for multi-word phrases
     word_with_underscores = word.replace(' ', '_')
-    
-    # Allow all Lithuanian letters, basic Latin letters, digits, and safe characters
-    sanitized = re.sub(r'[^a-z0-9' + LITHUANIAN_CHARS + r'\-_]', '', word_with_underscores)
-    
+
+    # Use provided character set or default to Lithuanian
+    chars = character_set if character_set is not None else LITHUANIAN_CHARS
+
+    # Allow specified letters, basic Latin letters, digits, and safe characters
+    sanitized = re.sub(r'[^a-z0-9' + chars + r'\-_]', '', word_with_underscores)
+
     if not sanitized or len(sanitized) > 100:
         return ""
-        
+
     return sanitized
 
 


### PR DESCRIPTION
Implement support for four languages (Lithuanian, Chinese, Korean, French) with language detection via subdomain and separate stats/audio per language.

Changes:
- Add language configuration system (LanguageManager) with languages.toml
- Update audio endpoints to support multiple languages
  - New generic endpoints use current language from subdomain
  - Language-specific endpoints: /api/{language}/audio/*
  - Legacy /api/lithuanian/* endpoints remain for compatibility
- Separate user stats by language
  - Stats stored in: data/trakaido/{user_id}/{language}/
  - All stats endpoints use current language from request context
- Add language detection middleware in before_request_handler
- Update constants to support multi-language audio directories

Language is determined by subdomain:
- zh.example.com -> Chinese
- fr.example.com -> French
- ko.example.com or kr.example.com -> Korean
- lt.example.com -> Lithuanian (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)