### PR TITLE
Add Japanese language configuration to config/languages.toml

### DIFF
--- a/config/languages.toml
+++ b/config/languages.toml
@@ -65,5 +65,12 @@
     subdomains = ["sv"]
     character_set = "aäåbcdeéfghijklmnoöpqrstuvwxyz"
 
+  # Japanese language configuration
+  [languages.japanese]
+    name = "Japanese"
+    code = "ja"
+    subdomains = ["ja"]
+    character_set = ""
+
 [defaults]
   default_language = "lithuanian"


### PR DESCRIPTION
### Motivation
- Add basic Japanese locale config so the application recognizes the `ja` language and subdomain for future localization work.

### Description
- Added a new `[languages.japanese]` block to `config/languages.toml` with `name = "Japanese"`, `code = "ja"`, `subdomains = ["ja"]`, and an empty `character_set`.

### Testing
- Ran configuration parsing and the project's automated test suite (`make test`) and linter checks, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b0839f648327a9ec960d01ff2d41)