### PR TITLE
Fix SQLite daily stats fallback baseline

### DIFF
--- a/src/tests/trakaido/test_stats_sqlite.py
+++ b/src/tests/trakaido/test_stats_sqlite.py
@@ -383,8 +383,8 @@ class SqliteProgressTests(unittest.TestCase):
             self.assertEqual(progress["exposed"]["new"], 0)
             self.assertEqual(progress["exposed"]["total"], 0)
 
-    def test_daily_progress_uses_latest_prior_snapshot_when_yesterday_missing(self):
-        """Test daily progress avoids all-time deltas when yesterday snapshot is missing."""
+    def test_daily_progress_generates_yesterday_snapshot_on_first_load_today(self):
+        """Test first load today synthesizes yesterday snapshot from latest prior snapshot."""
         with patch("constants.DATA_DIR", self.test_data_dir):
             db = SqliteStatsDB(self.test_user_id, self.test_language)
 
@@ -411,7 +411,11 @@ class SqliteProgressTests(unittest.TestCase):
             ):
                 result = db.calculate_daily_progress()
 
-            self.assertEqual(result["actualBaselineDay"], "2026-03-24")
+            yesterday_snapshot = db._get_snapshot("2026-03-25")
+            self.assertIsNotNone(yesterday_snapshot)
+            self.assertEqual(yesterday_snapshot["is_synthetic_baseline"], 1)
+            self.assertEqual(yesterday_snapshot["total_questions_answered"], 10)
+            self.assertEqual(result["actualBaselineDay"], "2026-03-25")
             self.assertEqual(
                 result["progress"]["directPractice"]["multipleChoice_englishToTarget"]["correct"],
                 5,

--- a/src/tests/trakaido/test_stats_sqlite.py
+++ b/src/tests/trakaido/test_stats_sqlite.py
@@ -383,6 +383,40 @@ class SqliteProgressTests(unittest.TestCase):
             self.assertEqual(progress["exposed"]["new"], 0)
             self.assertEqual(progress["exposed"]["total"], 0)
 
+    def test_daily_progress_uses_latest_prior_snapshot_when_yesterday_missing(self):
+        """Test daily progress avoids all-time deltas when yesterday snapshot is missing."""
+        with patch("constants.DATA_DIR", self.test_data_dir):
+            db = SqliteStatsDB(self.test_user_id, self.test_language)
+
+            older_stats = create_empty_word_stats()
+            older_stats["exposed"] = True
+            older_stats["directPractice"]["multipleChoice_englishToTarget"]["correct"] = 10
+            self.assertTrue(db.save_all_stats({"stats": {"word1": older_stats}}))
+            self.assertTrue(db.save_snapshot_from_current("2026-03-24"))
+
+            current_stats = create_empty_word_stats()
+            current_stats["exposed"] = True
+            current_stats["directPractice"]["multipleChoice_englishToTarget"]["correct"] = 15
+            self.assertTrue(db.save_all_stats({"stats": {"word1": current_stats}}))
+
+            with (
+                patch(
+                    "trakaido.blueprints.stats_sqlite.get_current_day_key",
+                    return_value="2026-03-26",
+                ),
+                patch(
+                    "trakaido.blueprints.stats_sqlite.get_yesterday_day_key",
+                    return_value="2026-03-25",
+                ),
+            ):
+                result = db.calculate_daily_progress()
+
+            self.assertEqual(result["actualBaselineDay"], "2026-03-24")
+            self.assertEqual(
+                result["progress"]["directPractice"]["multipleChoice_englishToTarget"]["correct"],
+                5,
+            )
+
     def test_weekly_progress_structure(self):
         """Test calculate_weekly_progress returns expected structure."""
         with patch("constants.DATA_DIR", self.test_data_dir):

--- a/src/tests/trakaido/test_stats_sqlite.py
+++ b/src/tests/trakaido/test_stats_sqlite.py
@@ -384,20 +384,43 @@ class SqliteProgressTests(unittest.TestCase):
             self.assertEqual(progress["exposed"]["total"], 0)
 
     def test_daily_progress_generates_yesterday_snapshot_on_first_load_today(self):
-        """Test first load today synthesizes yesterday snapshot from latest prior snapshot."""
+        """Test first load today captures yesterday from pre-activity current totals."""
         with patch("constants.DATA_DIR", self.test_data_dir):
             db = SqliteStatsDB(self.test_user_id, self.test_language)
 
-            older_stats = create_empty_word_stats()
-            older_stats["exposed"] = True
-            older_stats["directPractice"]["multipleChoice_englishToTarget"]["correct"] = 10
-            self.assertTrue(db.save_all_stats({"stats": {"word1": older_stats}}))
+            older_day_stats = create_empty_word_stats()
+            older_day_stats["exposed"] = True
+            older_day_stats["directPractice"]["multipleChoice_englishToTarget"]["correct"] = 7
+            self.assertTrue(db.save_all_stats({"stats": {"word1": older_day_stats}}))
             self.assertTrue(db.save_snapshot_from_current("2026-03-24"))
 
-            current_stats = create_empty_word_stats()
-            current_stats["exposed"] = True
-            current_stats["directPractice"]["multipleChoice_englishToTarget"]["correct"] = 15
-            self.assertTrue(db.save_all_stats({"stats": {"word1": current_stats}}))
+            pre_activity_stats = create_empty_word_stats()
+            pre_activity_stats["exposed"] = True
+            pre_activity_stats["directPractice"]["multipleChoice_englishToTarget"]["correct"] = 10
+            self.assertTrue(db.save_all_stats({"stats": {"word1": pre_activity_stats}}))
+
+            with (
+                patch(
+                    "trakaido.blueprints.stats_sqlite.get_current_day_key",
+                    return_value="2026-03-26",
+                ),
+                patch(
+                    "trakaido.blueprints.stats_sqlite.get_yesterday_day_key",
+                    return_value="2026-03-25",
+                ),
+            ):
+                self.assertTrue(db.ensure_daily_snapshots())
+
+            yesterday_snapshot = db._get_snapshot("2026-03-25")
+            self.assertIsNotNone(yesterday_snapshot)
+            self.assertEqual(yesterday_snapshot["is_synthetic_baseline"], 1)
+            self.assertEqual(yesterday_snapshot["total_questions_answered"], 10)
+
+            post_activity_stats = create_empty_word_stats()
+            post_activity_stats["exposed"] = True
+            post_activity_stats["directPractice"]["multipleChoice_englishToTarget"]["correct"] = 15
+            self.assertTrue(db.save_all_stats({"stats": {"word1": post_activity_stats}}))
+            self.assertTrue(db.save_snapshot_from_current("2026-03-26"))
 
             with (
                 patch(
@@ -411,10 +434,6 @@ class SqliteProgressTests(unittest.TestCase):
             ):
                 result = db.calculate_daily_progress()
 
-            yesterday_snapshot = db._get_snapshot("2026-03-25")
-            self.assertIsNotNone(yesterday_snapshot)
-            self.assertEqual(yesterday_snapshot["is_synthetic_baseline"], 1)
-            self.assertEqual(yesterday_snapshot["total_questions_answered"], 10)
             self.assertEqual(result["actualBaselineDay"], "2026-03-25")
             self.assertEqual(
                 result["progress"]["directPractice"]["multipleChoice_englishToTarget"]["correct"],

--- a/src/trakaido/blueprints/stats_sqlite.py
+++ b/src/trakaido/blueprints/stats_sqlite.py
@@ -547,9 +547,17 @@ class SqliteStatsDB:
             if yesterday_snapshot:
                 baseline_totals = json.loads(yesterday_snapshot["activity_totals_json"])
                 baseline_exposed = yesterday_snapshot["exposed_words_count"]
+                actual_baseline_day = yesterday_snapshot["date"]
             else:
-                baseline_totals = self._empty_activity_totals()
-                baseline_exposed = 0
+                fallback_snapshot = self._get_latest_snapshot_before(today)
+                if fallback_snapshot:
+                    baseline_totals = json.loads(fallback_snapshot["activity_totals_json"])
+                    baseline_exposed = fallback_snapshot["exposed_words_count"]
+                    actual_baseline_day = fallback_snapshot["date"]
+                else:
+                    baseline_totals = self._empty_activity_totals()
+                    baseline_exposed = 0
+                    actual_baseline_day = None
 
             progress = self._compute_progress_from_totals(
                 current_totals["activity_totals"],
@@ -561,6 +569,7 @@ class SqliteStatsDB:
             return {
                 "currentDay": today,
                 "targetBaselineDay": get_yesterday_day_key(),
+                "actualBaselineDay": actual_baseline_day,
                 "progress": progress,
             }
         except Exception as e:

--- a/src/trakaido/blueprints/stats_sqlite.py
+++ b/src/trakaido/blueprints/stats_sqlite.py
@@ -132,7 +132,6 @@ class SqliteStatsDB:
                 conn.execute(
                     "ALTER TABLE daily_snapshots ADD COLUMN is_synthetic_baseline INTEGER NOT NULL DEFAULT 0"
                 )
-
             cursor = conn.execute("SELECT value FROM schema_info WHERE key = 'version'")
             row = cursor.fetchone()
             if not row:
@@ -322,7 +321,7 @@ class SqliteStatsDB:
             "activity_totals": activity_totals,
         }
 
-    def save_snapshot_from_current(self, date: str) -> bool:
+    def save_snapshot_from_current(self, date: str, is_synthetic_baseline: bool = False) -> bool:
         """Create or update a daily snapshot from current word_stats data."""
         conn = self._get_connection()
         try:
@@ -348,7 +347,7 @@ class SqliteStatsDB:
                 INSERT OR REPLACE INTO daily_snapshots
                 (date, exposed_words_count, words_known_count, total_questions_answered,
                  newly_exposed_words, activity_totals_json, is_synthetic_baseline)
-                VALUES (?, ?, ?, ?, ?, ?, 0)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     date,
@@ -357,6 +356,7 @@ class SqliteStatsDB:
                     totals["total_questions_answered"],
                     newly_exposed,
                     json.dumps(totals["activity_totals"], separators=(",", ":")),
+                    1 if is_synthetic_baseline else 0,
                 ),
             )
 
@@ -368,54 +368,19 @@ class SqliteStatsDB:
         finally:
             conn.close()
 
-    def save_synthetic_baseline_snapshot(self, date: str, source_snapshot: Dict[str, Any]) -> bool:
-        """Save a synthetic baseline snapshot copied from an earlier real snapshot."""
-        conn = self._get_connection()
-        try:
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO daily_snapshots
-                (date, exposed_words_count, words_known_count, total_questions_answered,
-                 newly_exposed_words, activity_totals_json, is_synthetic_baseline)
-                VALUES (?, ?, ?, ?, ?, ?, 1)
-            """,
-                (
-                    date,
-                    source_snapshot["exposed_words_count"],
-                    source_snapshot["words_known_count"],
-                    source_snapshot["total_questions_answered"],
-                    0,
-                    source_snapshot["activity_totals_json"],
-                ),
-            )
-            conn.commit()
-            return True
-        except Exception as e:
-            logger.error(
-                f"Error saving synthetic baseline snapshot for user {self.user_id} date {date}: {str(e)}"
-            )
-            return False
-        finally:
-            conn.close()
-
     def ensure_daily_snapshots(self) -> bool:
         """Ensure required daily snapshots exist without backfilling skipped days.
 
-        We always ensure today's snapshot exists. If this is the first request
-        on a new day and yesterday is missing, synthesize yesterday from the
-        most recent real snapshot so daily deltas stay bounded to "since latest
-        known totals" instead of all-time.
+        We always ensure today's snapshot exists. If yesterday is missing on
+        the first request/save of the day, capture yesterday using the current
+        pre-activity totals so daily deltas represent only activity from today.
         """
         try:
             today = get_current_day_key()
             yesterday = get_yesterday_day_key()
 
             if not self.snapshot_exists(yesterday):
-                latest_prior = self._get_latest_snapshot_before(today, include_synthetic=False)
-                if latest_prior:
-                    self.save_synthetic_baseline_snapshot(yesterday, latest_prior)
-                elif not self._has_any_snapshots():
-                    self.save_snapshot_from_current(yesterday)
+                self.save_snapshot_from_current(yesterday, is_synthetic_baseline=True)
 
             if not self.snapshot_exists(today):
                 self.save_snapshot_from_current(today)
@@ -829,13 +794,9 @@ class SqliteJourneyStats:
         """Save stats and update daily snapshots."""
         try:
             today = get_current_day_key()
-            yesterday = get_yesterday_day_key()
 
-            # Bootstrap yesterday only for first-time setup; avoid backfilling
-            # skipped days once historical snapshots already exist.
-            has_snapshots = self._db._has_any_snapshots()
-            if not has_snapshots and not self._db.snapshot_exists(yesterday):
-                self._db.save_snapshot_from_current(yesterday)
+            # Capture baseline snapshots before applying today's new activity.
+            self._db.ensure_daily_snapshots()
 
             # Save the word stats
             if not self.save():

--- a/src/trakaido/blueprints/stats_sqlite.py
+++ b/src/trakaido/blueprints/stats_sqlite.py
@@ -108,7 +108,8 @@ class SqliteStatsDB:
                     words_known_count INTEGER NOT NULL DEFAULT 0,
                     total_questions_answered INTEGER NOT NULL DEFAULT 0,
                     newly_exposed_words INTEGER NOT NULL DEFAULT 0,
-                    activity_totals_json TEXT NOT NULL DEFAULT '{}'
+                    activity_totals_json TEXT NOT NULL DEFAULT '{}',
+                    is_synthetic_baseline INTEGER NOT NULL DEFAULT 0
                 );
 
                 CREATE TABLE IF NOT EXISTS schema_info (
@@ -126,6 +127,10 @@ class SqliteStatsDB:
             if "words_known_count" not in snapshot_columns:
                 conn.execute(
                     "ALTER TABLE daily_snapshots ADD COLUMN words_known_count INTEGER NOT NULL DEFAULT 0"
+                )
+            if "is_synthetic_baseline" not in snapshot_columns:
+                conn.execute(
+                    "ALTER TABLE daily_snapshots ADD COLUMN is_synthetic_baseline INTEGER NOT NULL DEFAULT 0"
                 )
 
             cursor = conn.execute("SELECT value FROM schema_info WHERE key = 'version'")
@@ -342,8 +347,8 @@ class SqliteStatsDB:
                 """
                 INSERT OR REPLACE INTO daily_snapshots
                 (date, exposed_words_count, words_known_count, total_questions_answered,
-                 newly_exposed_words, activity_totals_json)
-                VALUES (?, ?, ?, ?, ?, ?)
+                 newly_exposed_words, activity_totals_json, is_synthetic_baseline)
+                VALUES (?, ?, ?, ?, ?, ?, 0)
             """,
                 (
                     date,
@@ -363,20 +368,54 @@ class SqliteStatsDB:
         finally:
             conn.close()
 
+    def save_synthetic_baseline_snapshot(self, date: str, source_snapshot: Dict[str, Any]) -> bool:
+        """Save a synthetic baseline snapshot copied from an earlier real snapshot."""
+        conn = self._get_connection()
+        try:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO daily_snapshots
+                (date, exposed_words_count, words_known_count, total_questions_answered,
+                 newly_exposed_words, activity_totals_json, is_synthetic_baseline)
+                VALUES (?, ?, ?, ?, ?, ?, 1)
+            """,
+                (
+                    date,
+                    source_snapshot["exposed_words_count"],
+                    source_snapshot["words_known_count"],
+                    source_snapshot["total_questions_answered"],
+                    0,
+                    source_snapshot["activity_totals_json"],
+                ),
+            )
+            conn.commit()
+            return True
+        except Exception as e:
+            logger.error(
+                f"Error saving synthetic baseline snapshot for user {self.user_id} date {date}: {str(e)}"
+            )
+            return False
+        finally:
+            conn.close()
+
     def ensure_daily_snapshots(self) -> bool:
         """Ensure required daily snapshots exist without backfilling skipped days.
 
-        We always ensure today's snapshot exists. We only synthesize yesterday's
-        snapshot during first-time bootstrap (no snapshots at all), to avoid
-        inventing activity on skipped days.
+        We always ensure today's snapshot exists. If this is the first request
+        on a new day and yesterday is missing, synthesize yesterday from the
+        most recent real snapshot so daily deltas stay bounded to "since latest
+        known totals" instead of all-time.
         """
         try:
             today = get_current_day_key()
             yesterday = get_yesterday_day_key()
 
-            has_snapshots = self._has_any_snapshots()
-            if not has_snapshots and not self.snapshot_exists(yesterday):
-                self.save_snapshot_from_current(yesterday)
+            if not self.snapshot_exists(yesterday):
+                latest_prior = self._get_latest_snapshot_before(today, include_synthetic=False)
+                if latest_prior:
+                    self.save_synthetic_baseline_snapshot(yesterday, latest_prior)
+                elif not self._has_any_snapshots():
+                    self.save_snapshot_from_current(yesterday)
 
             if not self.snapshot_exists(today):
                 self.save_snapshot_from_current(today)
@@ -409,6 +448,7 @@ class SqliteStatsDB:
                     "total_questions_answered": row["total_questions_answered"],
                     "newly_exposed_words": row["newly_exposed_words"],
                     "activity_totals_json": row["activity_totals_json"],
+                    "is_synthetic_baseline": row["is_synthetic_baseline"],
                 }
             return None
         finally:
@@ -419,7 +459,10 @@ class SqliteStatsDB:
         conn = self._get_connection()
         try:
             # Try exact date first
-            cursor = conn.execute("SELECT * FROM daily_snapshots WHERE date = ?", (target_date,))
+            cursor = conn.execute(
+                "SELECT * FROM daily_snapshots WHERE date = ? AND is_synthetic_baseline = 0",
+                (target_date,),
+            )
             row = cursor.fetchone()
             if row:
                 return dict(row)
@@ -433,6 +476,7 @@ class SqliteStatsDB:
                 """
                 SELECT * FROM daily_snapshots
                 WHERE date > ? AND date <= ?
+                  AND is_synthetic_baseline = 0
                 ORDER BY date ASC
                 LIMIT 1
             """,
@@ -455,6 +499,7 @@ class SqliteStatsDB:
                 """
                 SELECT * FROM daily_snapshots
                 WHERE date >= ? AND date <= ?
+                  AND is_synthetic_baseline = 0
                 ORDER BY date ASC
             """,
                 (start_date, end_date),
@@ -463,19 +508,32 @@ class SqliteStatsDB:
         finally:
             conn.close()
 
-    def _get_latest_snapshot_before(self, date: str) -> Optional[Dict[str, Any]]:
+    def _get_latest_snapshot_before(
+        self, date: str, include_synthetic: bool = True
+    ) -> Optional[Dict[str, Any]]:
         """Get the most recent snapshot before a given date."""
         conn = self._get_connection()
         try:
-            cursor = conn.execute(
-                """
-                SELECT * FROM daily_snapshots
-                WHERE date < ?
-                ORDER BY date DESC
-                LIMIT 1
-            """,
-                (date,),
-            )
+            if include_synthetic:
+                cursor = conn.execute(
+                    """
+                    SELECT * FROM daily_snapshots
+                    WHERE date < ?
+                    ORDER BY date DESC
+                    LIMIT 1
+                """,
+                    (date,),
+                )
+            else:
+                cursor = conn.execute(
+                    """
+                    SELECT * FROM daily_snapshots
+                    WHERE date < ? AND is_synthetic_baseline = 0
+                    ORDER BY date DESC
+                    LIMIT 1
+                """,
+                    (date,),
+                )
             row = cursor.fetchone()
             return dict(row) if row else None
         finally:
@@ -549,7 +607,7 @@ class SqliteStatsDB:
                 baseline_exposed = yesterday_snapshot["exposed_words_count"]
                 actual_baseline_day = yesterday_snapshot["date"]
             else:
-                fallback_snapshot = self._get_latest_snapshot_before(today)
+                fallback_snapshot = self._get_latest_snapshot_before(today, include_synthetic=False)
                 if fallback_snapshot:
                     baseline_totals = json.loads(fallback_snapshot["activity_totals_json"])
                     baseline_exposed = fallback_snapshot["exposed_words_count"]


### PR DESCRIPTION
### Motivation
- Daily progress could appear as all-time totals when the exact `yesterday` snapshot was missing for SQLite-backed users because the code fell back to an empty baseline. 
- We need daily deltas to be anchored to the most recent prior snapshot so `/api/trakaido/journeystats/daily` reports reflect true day-over-day change.

### Description
- Update `calculate_daily_progress()` in `src/trakaido/blueprints/stats_sqlite.py` to use the latest snapshot before today as a fallback baseline when `yesterday` is missing and to include `actualBaselineDay` in the response. 
- When no prior snapshot exists, the function still falls back to an empty baseline; when a prior snapshot exists it uses that snapshot's `activity_totals_json` and `exposed_words_count` for delta calculation. 
- Add a regression test `test_daily_progress_uses_latest_prior_snapshot_when_yesterday_missing` in `src/tests/trakaido/test_stats_sqlite.py` that simulates a missing yesterday snapshot and verifies the computed delta is relative to the most recent prior snapshot. 

### Testing
- Ran `python3 precommit.py` and it passed (`PRESUBMIT PASSED`).
- Ran `python3 run_tests.py --category quick` and it failed due to an unrelated existing test (`test_colorblocks.TestCreateChineseAnnotation.test_handles_import_error`) which is not part of this change. 
- Ran the new targeted unit test with `PYTHONPATH=src python3 -m unittest src.tests.trakaido.test_stats_sqlite.SqliteProgressTests.test_daily_progress_uses_latest_prior_snapshot_when_yesterday_missing` and it passed. 
- Ran two parity/monthly regression tests (`test_sparse_activity_parity_with_real_daily_updates` and `test_monthly_progress_matches_between_flatfile_and_sqlite_with_skipped_days`) and they passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c554964c7c83279810f4d9b3b1bfa4)