### PR TITLE
Add Trakaido Prometheus metric (total users), endpoint integration, docs, and tests

### DIFF
--- a/docs/prometheus_blog_metrics.md
+++ b/docs/prometheus_blog_metrics.md
@@ -1,6 +1,6 @@
 # Prometheus variables: Atacama main (BLOG) server
 
-These metrics are exported by the shared `/metrics` endpoint when `BLUEPRINT_SET=BLOG`, and they cover host health, process health, HTTP behavior, auth activity, and blog content inventory. This list is intended for monitoring configuration and includes only Atacama-defined metric names (Prometheus client default runtime metrics like `process_*` and `python_*` are available separately).
+These metrics are exported by the shared `/metrics` endpoint when `BLUEPRINT_SET=BLOG`, and they cover host health, process health, HTTP behavior, auth activity, and blog content inventory. Host-level disk metrics are included for completeness, but in most deployments you should prefer `node_exporter` as the primary source for machine-wide disk alerts.
 
 - `atacama_cpu_usage_percent`
 - `atacama_memory_usage_percent`

--- a/docs/prometheus_blog_metrics.md
+++ b/docs/prometheus_blog_metrics.md
@@ -1,0 +1,27 @@
+# Prometheus variables: Atacama main (BLOG) server
+
+These metrics are exported by the shared `/metrics` endpoint when `BLUEPRINT_SET=BLOG`, and they cover host health, process health, HTTP behavior, auth activity, and blog content inventory. This list is intended for monitoring configuration and includes only Atacama-defined metric names (Prometheus client default runtime metrics like `process_*` and `python_*` are available separately).
+
+- `atacama_cpu_usage_percent`
+- `atacama_memory_usage_percent`
+- `atacama_memory_used_bytes`
+- `atacama_memory_total_bytes`
+- `atacama_disk_usage_percent`
+- `atacama_disk_used_bytes`
+- `atacama_disk_total_bytes`
+- `atacama_network_bytes_sent_total`
+- `atacama_network_bytes_recv_total`
+- `atacama_process_cpu_percent`
+- `atacama_process_memory_bytes`
+- `atacama_process_threads`
+- `atacama_process_open_fds`
+- `atacama_uptime_seconds`
+- `atacama_content_count{content_type="emails|articles|widgets|quotes"}`
+- `atacama_database_connected`
+- `atacama_http_requests_total{method,endpoint,status}`
+- `atacama_http_request_duration_seconds{method,endpoint}`
+- `atacama_http_errors_total{status_class="4xx|5xx"}`
+- `atacama_auth_logins_total{provider,status}`
+- `atacama_auth_logouts_total`
+- `atacama_db_session_duration_seconds`
+- `atacama_db_query_errors_total`

--- a/docs/prometheus_trakaido_metrics.md
+++ b/docs/prometheus_trakaido_metrics.md
@@ -1,0 +1,27 @@
+# Prometheus variables: Trakaido API server
+
+These metrics are exported by the shared `/metrics` endpoint when `BLUEPRINT_SET=TRAKAIDO`, and they provide system/process/HTTP/database visibility plus a Trakaido-specific total-user gauge. This list is intended for monitoring configuration and includes only Atacama-defined metric names (Prometheus client default runtime metrics like `process_*` and `python_*` are available separately).
+
+- `atacama_cpu_usage_percent`
+- `atacama_memory_usage_percent`
+- `atacama_memory_used_bytes`
+- `atacama_memory_total_bytes`
+- `atacama_disk_usage_percent`
+- `atacama_disk_used_bytes`
+- `atacama_disk_total_bytes`
+- `atacama_network_bytes_sent_total`
+- `atacama_network_bytes_recv_total`
+- `atacama_process_cpu_percent`
+- `atacama_process_memory_bytes`
+- `atacama_process_threads`
+- `atacama_process_open_fds`
+- `atacama_uptime_seconds`
+- `atacama_database_connected`
+- `atacama_http_requests_total{method,endpoint,status}`
+- `atacama_http_request_duration_seconds{method,endpoint}`
+- `atacama_http_errors_total{status_class="4xx|5xx"}`
+- `atacama_auth_logins_total{provider,status}`
+- `atacama_auth_logouts_total`
+- `atacama_db_session_duration_seconds`
+- `atacama_db_query_errors_total`
+- `atacama_trakaido_total_users`

--- a/docs/prometheus_trakaido_metrics.md
+++ b/docs/prometheus_trakaido_metrics.md
@@ -1,6 +1,6 @@
 # Prometheus variables: Trakaido API server
 
-These metrics are exported by the shared `/metrics` endpoint when `BLUEPRINT_SET=TRAKAIDO`, and they provide system/process/HTTP/database visibility plus a Trakaido-specific total-user gauge. This list is intended for monitoring configuration and includes only Atacama-defined metric names (Prometheus client default runtime metrics like `process_*` and `python_*` are available separately).
+These metrics are exported by the shared `/metrics` endpoint when `BLUEPRINT_SET=TRAKAIDO`, and they provide system/process/HTTP/database visibility plus Trakaido-specific user-activity gauges. Host-level disk metrics are included for completeness, but in most deployments you should prefer `node_exporter` as the primary source for machine-wide disk alerts.
 
 - `atacama_cpu_usage_percent`
 - `atacama_memory_usage_percent`
@@ -25,3 +25,5 @@ These metrics are exported by the shared `/metrics` endpoint when `BLUEPRINT_SET
 - `atacama_db_session_duration_seconds`
 - `atacama_db_query_errors_total`
 - `atacama_trakaido_total_users`
+- `atacama_trakaido_active_users_last_hour`
+- `atacama_trakaido_active_users_by_language{language}`

--- a/src/atacama/blueprints/metrics.py
+++ b/src/atacama/blueprints/metrics.py
@@ -303,6 +303,10 @@ def metrics():
     # Only update content metrics for BLOG blueprint set to avoid errors in TRAKAIDO mode
     if current_app.config.get("BLUEPRINT_SET") == "BLOG":
         update_content_metrics()
+    elif current_app.config.get("BLUEPRINT_SET") == "TRAKAIDO":
+        from trakaido.blueprints.metrics import update_trakaido_metrics
+
+        update_trakaido_metrics()
 
     return Response(generate_latest(REGISTRY), mimetype=CONTENT_TYPE_LATEST)
 

--- a/src/atacama/blueprints/metrics.py
+++ b/src/atacama/blueprints/metrics.py
@@ -366,4 +366,13 @@ def setup_request_metrics(app):
                 status_class = "4xx" if response.status_code < 500 else "5xx"
                 http_errors_total.labels(status_class=status_class).inc()
 
+        # Track in-memory activity metrics for Trakaido users.
+        if current_app.config.get("BLUEPRINT_SET") == "TRAKAIDO":
+            user = getattr(g, "user", None)
+            if user and getattr(user, "id", None) is not None:
+                from trakaido.blueprints.metrics import record_trakaido_activity
+
+                language = getattr(g, "current_language", "lithuanian")
+                record_trakaido_activity(str(user.id), language)
+
         return response

--- a/src/tests/atacama/test_metrics.py
+++ b/src/tests/atacama/test_metrics.py
@@ -155,6 +155,11 @@ class TrakaidoMetricsTests(unittest.TestCase):
         response = self.client.get("/metrics")
         self.assertIn(b"atacama_uptime_seconds", response.data)
 
+    def test_trakaido_metrics_contains_total_users(self):
+        """Test that TRAKAIDO mode includes total users metric."""
+        response = self.client.get("/metrics")
+        self.assertIn(b"atacama_trakaido_total_users", response.data)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/tests/atacama/test_metrics.py
+++ b/src/tests/atacama/test_metrics.py
@@ -160,6 +160,16 @@ class TrakaidoMetricsTests(unittest.TestCase):
         response = self.client.get("/metrics")
         self.assertIn(b"atacama_trakaido_total_users", response.data)
 
+    def test_trakaido_metrics_contains_active_users_last_hour(self):
+        """Test that TRAKAIDO mode includes active users in last hour metric."""
+        response = self.client.get("/metrics")
+        self.assertIn(b"atacama_trakaido_active_users_last_hour", response.data)
+
+    def test_trakaido_metrics_contains_active_users_by_language(self):
+        """Test that TRAKAIDO mode includes active users by language metric."""
+        response = self.client.get("/metrics")
+        self.assertIn(b"atacama_trakaido_active_users_by_language", response.data)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/trakaido/blueprints/metrics.py
+++ b/src/trakaido/blueprints/metrics.py
@@ -1,6 +1,10 @@
 """Trakaido-specific Prometheus metrics."""
 
+import time
+from threading import Lock
+
 from common.base.logging_config import get_logger
+from common.config.language_config import get_language_manager
 
 logger = get_logger(__name__)
 
@@ -26,6 +30,50 @@ trakaido_total_users = Gauge(
     "atacama_trakaido_total_users", "Total number of users in the Trakaido user database"
 )
 
+trakaido_active_users_last_hour = Gauge(
+    "atacama_trakaido_active_users_last_hour",
+    "Number of distinct Trakaido users active in the last hour (in-memory, per server)",
+)
+
+trakaido_active_users_by_language = Gauge(
+    "atacama_trakaido_active_users_by_language",
+    "Number of distinct Trakaido users active in the last hour by language (in-memory, per server)",
+    ["language"],
+)
+
+_ACTIVE_WINDOW_SECONDS = 3600
+_activity_lock = Lock()
+_user_last_seen: dict[str, tuple[float, str]] = {}
+
+
+def record_trakaido_activity(user_id: str, language: str) -> None:
+    """Record in-memory user activity for active-user metrics."""
+    if not user_id:
+        return
+
+    normalized_language = language or "unknown"
+    with _activity_lock:
+        _user_last_seen[user_id] = (time.time(), normalized_language)
+
+
+def _compute_active_user_snapshot() -> tuple[int, dict[str, int]]:
+    """Compute active-user counts over the rolling active window."""
+    cutoff = time.time() - _ACTIVE_WINDOW_SECONDS
+    active_by_language: dict[str, int] = {}
+
+    with _activity_lock:
+        stale_user_ids = []
+        for user_id, (last_seen_ts, language) in _user_last_seen.items():
+            if last_seen_ts < cutoff:
+                stale_user_ids.append(user_id)
+                continue
+            active_by_language[language] = active_by_language.get(language, 0) + 1
+
+        for user_id in stale_user_ids:
+            _user_last_seen.pop(user_id, None)
+
+    return sum(active_by_language.values()), active_by_language
+
 
 def update_trakaido_metrics():
     """Update Trakaido-specific metrics."""
@@ -35,5 +83,15 @@ def update_trakaido_metrics():
 
         with db.session() as db_session:
             trakaido_total_users.set(db_session.query(User).count())
+
+        active_total, active_by_language = _compute_active_user_snapshot()
+        trakaido_active_users_last_hour.set(active_total)
+
+        # Initialize configured languages to zero so label series are stable.
+        for language in get_language_manager().get_all_language_keys():
+            trakaido_active_users_by_language.labels(language=language).set(0)
+
+        for language, count in active_by_language.items():
+            trakaido_active_users_by_language.labels(language=language).set(count)
     except Exception as e:
         logger.warning(f"Error updating Trakaido metrics: {e}")

--- a/src/trakaido/blueprints/metrics.py
+++ b/src/trakaido/blueprints/metrics.py
@@ -1,0 +1,39 @@
+"""Trakaido-specific Prometheus metrics."""
+
+from common.base.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+try:
+    from prometheus_client import Gauge
+except ImportError:
+    logger.warning(
+        "prometheus_client is not installed. Trakaido metrics will be unavailable. "
+        "Install with: pip install prometheus_client"
+    )
+
+    class Gauge:
+        """No-op Gauge stub when prometheus_client is unavailable."""
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def set(self, value):
+            pass
+
+
+trakaido_total_users = Gauge(
+    "atacama_trakaido_total_users", "Total number of users in the Trakaido user database"
+)
+
+
+def update_trakaido_metrics():
+    """Update Trakaido-specific metrics."""
+    try:
+        from models.database import db
+        from models.models import User
+
+        with db.session() as db_session:
+            trakaido_total_users.set(db_session.query(User).count())
+    except Exception as e:
+        logger.warning(f"Error updating Trakaido metrics: {e}")


### PR DESCRIPTION
### Motivation
- Expose a Trakaido-specific Prometheus gauge for the total number of users so the shared `/metrics` endpoint can provide Trakaido-specific visibility when `BLUEPRINT_SET=TRAKAIDO`.
- Keep the metrics endpoint safe and mode-aware by only updating blueprint-specific metrics for the active blueprint set.
- Document available Prometheus variables for both BLOG and TRAKAIDO deployments to support monitoring configuration.

### Description
- Add `src/trakaido/blueprints/metrics.py` which defines `trakaido_total_users` Gauge and `update_trakaido_metrics()` that queries the `User` model and sets the gauge, with a no-op `Gauge` stub when `prometheus_client` is unavailable.
- Update `src/atacama/blueprints/metrics.py` to call `update_trakaido_metrics()` when `current_app.config.get("BLUEPRINT_SET") == "TRAKAIDO"` and retain existing BLOG content metrics behavior.
- Add documentation files `docs/prometheus_trakaido_metrics.md` and `docs/prometheus_blog_metrics.md` listing Atacama-defined metric names for each blueprint.
- Add a unit test `test_trakaido_metrics_contains_total_users` to `src/tests/atacama/test_metrics.py` to assert the `atacama_trakaido_total_users` metric appears in the `/metrics` response.

### Testing
- Ran unit tests in `src/tests/atacama/test_metrics.py` via the test runner, and `TrakaidoMetricsTests.test_trakaido_metrics_contains_total_users` passed.
- Existing metrics tests `test_trakaido_metrics_endpoint_returns_200` and `test_trakaido_metrics_contains_uptime` were executed and passed.
- No additional integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6eec765b883278c24effa290c517c)