### PR TITLE
Improve blog test coverage for article/feed/statistics endpoints

### DIFF
--- a/src/tests/blog/test_article_feeds_statistics.py
+++ b/src/tests/blog/test_article_feeds_statistics.py
@@ -1,0 +1,149 @@
+"""Tests for article, feed, and statistics blog endpoints."""
+
+import unittest
+from datetime import datetime
+
+from atacama.server import create_app
+from models.database import db
+from models.models import Article, Email, User
+
+
+class ArticleFeedStatisticsTests(unittest.TestCase):
+    """End-to-end tests for important blog endpoints."""
+
+    def setUp(self):
+        self.app = create_app(testing=True)
+        self.app.config.update({"TESTING": True, "SERVER_NAME": "test.local"})
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        db.cleanup()
+
+    def create_user(self, email="blogger@example.com", name="Blogger"):
+        with self.app.app_context():
+            with db.session() as db_session:
+                user = User(email=email, name=name)
+                db_session.add(user)
+                db_session.commit()
+                return user.id
+
+    def test_submit_and_view_article(self):
+        """Submitting an article should persist and be viewable by slug."""
+        user_id = self.create_user()
+
+        with self.app.app_context():
+            with db.session() as db_session:
+                user = db_session.query(User).filter_by(id=user_id).first()
+                with self.client.session_transaction() as sess:
+                    sess["user"] = {"email": user.email, "name": user.name}
+
+        response = self.client.post(
+            "/submit/article",
+            data={
+                "title": "Coverage Article",
+                "slug": "coverage-article",
+                "content": "<green>Coverage matters</green>",
+                "channel": "misc",
+                "publish": "true",
+            },
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/p/coverage-article", response.location)
+
+        article_response = self.client.get("/p/coverage-article")
+        self.assertEqual(article_response.status_code, 200)
+        self.assertIn(b"Coverage Article", article_response.data)
+
+    def test_rss_feed_excludes_private_messages(self):
+        """RSS should include public channel content and exclude private content."""
+        user_id = self.create_user("rss@example.com", "RSS User")
+
+        with self.app.app_context():
+            with db.session() as db_session:
+                db_session.add_all(
+                    [
+                        Email(
+                            author_id=user_id,
+                            channel="misc",
+                            subject="Public Entry",
+                            content="public body",
+                            processed_content="<p>public body</p>",
+                        ),
+                        Email(
+                            author_id=user_id,
+                            channel="private",
+                            subject="Private Entry",
+                            content="private body",
+                            processed_content="<p>private body</p>",
+                        ),
+                    ]
+                )
+                db_session.commit()
+
+        response = self.client.get("/feed.xml")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Public Entry", response.data)
+        self.assertNotIn(b"Private Entry", response.data)
+
+    def test_channel_statistics_endpoint(self):
+        """Statistics page should render and include seeded channel data."""
+        user_id = self.create_user("stats@example.com", "Stats User")
+
+        with self.app.app_context():
+            with db.session() as db_session:
+                db_session.add(
+                    Email(
+                        author_id=user_id,
+                        channel="misc",
+                        subject="Stats Subject",
+                        content="Stats Body",
+                        processed_content="Stats Body",
+                    )
+                )
+                db_session.commit()
+
+        response = self.client.get("/stats")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Channel Statistics", response.data)
+        self.assertIn(b"Miscellany", response.data)
+
+    def test_article_stream_shows_only_published(self):
+        """Channel article stream should only show published articles."""
+        user_id = self.create_user("articles@example.com", "Article User")
+
+        with self.app.app_context():
+            with db.session() as db_session:
+                db_session.add_all(
+                    [
+                        Article(
+                            author_id=user_id,
+                            channel="misc",
+                            slug="published-article",
+                            title="Published Article",
+                            content="published",
+                            processed_content="<p>published</p>",
+                            published=True,
+                            published_at=datetime.utcnow(),
+                        ),
+                        Article(
+                            author_id=user_id,
+                            channel="misc",
+                            slug="draft-article",
+                            title="Draft Article",
+                            content="draft",
+                            processed_content="<p>draft</p>",
+                            published=False,
+                        ),
+                    ]
+                )
+                db_session.commit()
+
+        response = self.client.get("/articles/channel/misc")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Published Article", response.data)
+        self.assertNotIn(b"Draft Article", response.data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/blog/test_content_serving.py
+++ b/src/tests/blog/test_content_serving.py
@@ -7,7 +7,7 @@ from unittest.mock import patch, Mock
 
 from atacama.server import create_app
 from models.database import db
-from models.models import User, Email, Article
+from models.models import User, Email
 
 
 class ContentServingTests(unittest.TestCase):
@@ -119,16 +119,16 @@ class ContentServingTests(unittest.TestCase):
 
         # Create messages in different channels
         self.create_test_message(user_id, channel="misc", subject="General Message")
-        self.create_test_message(user_id, channel="technology", subject="Tech Message")
+        self.create_test_message(user_id, channel="tech", subject="Tech Message")
 
         # Get general channel
-        response = self.client.get("/stream/channel/general")
+        response = self.client.get("/stream/channel/misc")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"General Message", response.data)
         self.assertNotIn(b"Tech Message", response.data)
 
         # Get technology channel
-        response = self.client.get("/stream/channel/technology")
+        response = self.client.get("/stream/channel/tech")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Tech Message", response.data)
         self.assertNotIn(b"General Message", response.data)
@@ -156,42 +156,18 @@ class ContentServingTests(unittest.TestCase):
             sess["user"] = {"email": "test@example.com", "name": "Test User"}
 
         # Update preferences
-        response = self.client.post(
-            "/channels", data={"channel_general": "on", "channel_technology": "on"}
-        )
+        response = self.client.post("/channels", data={"channel_misc": "on", "channel_tech": "on"})
 
         # Should redirect back to preferences page
         self.assertIn(response.status_code, [200, 302])
 
-    def test_message_with_article(self):
-        """Test retrieving a message that has an associated article."""
+    def test_message_with_html_rendering(self):
+        """Test retrieving a message as HTML."""
         user_id = self.create_test_user()
-
-        with self.app.app_context():
-            with db.session() as db_session:
-                # Create message with article
-                message = Email(
-                    author_id=user_id,
-                    channel="misc",
-                    subject="Article Message",
-                    content="Summary",
-                    processed_content="Summary",
-                )
-                db_session.add(message)
-                db_session.flush()
-
-                article = Article(
-                    message_id=message.id, content="<green>Full article content</green>"
-                )
-                db_session.add(article)
-                db_session.commit()
-                msg_id = message.id
-
-        response = self.client.get(f"/messages/{msg_id}")
-
+        msg_id = self.create_test_message(user_id, subject="Rendered Message", content="Body")
+        response = self.client.get(f"/messages/{msg_id}", headers={"Accept": "text/html"})
         self.assertEqual(response.status_code, 200)
-        data = response.get_json()
-        self.assertIn("article", data)
+        self.assertIn(b"Rendered Message", response.data)
 
     def test_timestamp_based_filtering(self):
         """Test filtering messages by timestamp."""
@@ -199,7 +175,7 @@ class ContentServingTests(unittest.TestCase):
         self.create_test_message(user_id, subject="Test Message")
 
         # Test with date-based URL
-        response = self.client.get("/stream/channel/general/before/2099-12-31/")
+        response = self.client.get("/stream/channel/misc/before/2099-12-31/")
         self.assertEqual(response.status_code, 200)
 
     def test_invalid_channel(self):
@@ -215,7 +191,7 @@ class ContentServingTests(unittest.TestCase):
         user_id = self.create_test_user()
         self.create_test_message(user_id, channel="misc")
 
-        response = self.client.get("/stream/channel/general")
+        response = self.client.get("/stream/channel/misc")
         self.assertEqual(response.status_code, 200)
 
 


### PR DESCRIPTION
### Motivation
- Bring blog coverage closer to parity with Trakaido and the AML parser by adding end-to-end tests for high-value HTTP flows. 
- Update fragile/dated test fixtures to match current channel configuration and actual endpoint behavior.

### Description
- Added `src/tests/blog/test_article_feeds_statistics.py` with end-to-end tests for article submission/view (`/submit/article`, `/p/<slug>`), RSS visibility (`/feed.xml`), channel statistics (`/stats`), and published-only article streams (`/articles/channel/misc`).
- Updated `src/tests/blog/test_content_serving.py` to align channel names and preference keys (`misc`/`tech`) and replaced an outdated message+article polymorphism assertion with an HTML rendering check for `/messages/<id>`.
- Ran formatter and pre-commit checks (`black`, `python3 precommit.py`) and kept changes limited to test files and test fixtures.

### Testing
- Ran `python3 precommit.py` which passed.
- Ran focused unit tests: `pytest -q src/tests/blog/test_article_feeds_statistics.py` (4 passed) and targeted content tests `pytest -q src/tests/blog/test_content_serving.py -k message_with_html_rendering` (2 passed).
- Ran a combined coverage run for the selected blog tests with `coverage run -m pytest ...` and reported per-file coverage for the exercised modules: `article.py` ~59%, `feeds.py` ~50%, `statistics.py` ~98%, `content.py` ~26%, overall focused blog coverage ~43% (this reflects the limited, targeted test set exercised in the run).
- Observed unrelated existing issues while exercising larger test sets: `python3 run_tests.py --category quick` and larger combined suites experienced a failing AML parser test and intermittent segmentation faults plus Trakaido DB initialization failures; these failures are pre-existing and outside the scope of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfda3c8d2c832796585d54b5d5e5c9)