### PR TITLE
Fix domain-aware HTTPS links and redirects

### DIFF
--- a/config/domains.toml
+++ b/config/domains.toml
@@ -28,6 +28,7 @@ excluded_domains = ["localhost", "127.0.0.1", "atacama.local"]
   [domains.earlyversion]
     name = "Early Version"
     domains = ["earlyversion.com"]
+    https_enabled = true
     channels = [
       "misc", "private", "sandbox", "sports", "politics", "religion", "chess",
       "books", "film", "music", "television", "orinoco", "linaja", "cities",
@@ -46,6 +47,7 @@ excluded_domains = ["localhost", "127.0.0.1", "atacama.local"]
   [domains.pow3]
     name = "Alex Power's blog"
     domains = ["blog.pow3.com"]
+    https_enabled = true
     channels = ["tech", "llm", "atacama", "barsukas", "trakaido", "gardening"]
     theme = "pow3"
     description = "technology blog"
@@ -54,6 +56,7 @@ excluded_domains = ["localhost", "127.0.0.1", "atacama.local"]
   [domains.shragafeivel]
     name = "Shragafeivel"
     domains = ["shragafeivel.com"]
+    https_enabled = true
     channels = ["religion", "usconst", "chess", "education", "highphysics"]
     theme = "shragafeivel"
     # Optional domain-specific settings

--- a/src/atacama/nginx.conf
+++ b/src/atacama/nginx.conf
@@ -13,11 +13,11 @@ upstream trakaido {
 # HTTP Server - both domains
 server {
     listen 80;
-    server_name earlyversion.com shragafeivel.com www.earlyversion.com www.shragafeivel.com;
+    server_name earlyversion.com shragafeivel.com blog.pow3.com www.earlyversion.com www.shragafeivel.com;
     
     # Redirect all HTTP requests to HTTPS
     location / {
-        return 301 https://$server_name$request_uri;
+        return 301 https://$host$request_uri;
     }
 
     # Let's Encrypt validation

--- a/src/atacama/server.py
+++ b/src/atacama/server.py
@@ -4,7 +4,7 @@
 
 import os
 from pathlib import Path
-from flask import Flask, request, g
+from flask import Flask, request, g, redirect
 from waitress import serve  # type: ignore[import-untyped]
 from typing import Dict, Any, Optional, List, Tuple
 
@@ -63,6 +63,10 @@ def before_request_handler():
     # Determine current domain based on host
     domain_key = domain_manager.get_domain_for_host(host)
     domain_config = domain_manager.get_domain_config(domain_key)
+
+    if domain_config.https_enabled and request.scheme != "https":
+        secure_url = request.url.replace("http://", "https://", 1)
+        return redirect(secure_url, code=301)
 
     # Get theme configuration
     theme_key = domain_config.theme

--- a/src/blog/blueprints/admin.py
+++ b/src/blog/blueprints/admin.py
@@ -56,7 +56,7 @@ def _build_submission_domain_links(
     message_id: int,
     current_domain: str,
     current_host: str,
-    scheme: str,
+    current_scheme: str,
 ) -> List[Dict[str, Any]]:
     """
     Build display/link data for domains that serve a channel.
@@ -65,7 +65,7 @@ def _build_submission_domain_links(
     :param message_id: Message ID to link to
     :param current_domain: Current request domain key
     :param current_host: Current request host (without port)
-    :param scheme: Request scheme (http/https)
+    :param current_scheme: Current request scheme (http/https)
     :return: List of domain dictionaries for template display
     """
     domain_manager = get_domain_manager()
@@ -80,6 +80,7 @@ def _build_submission_domain_links(
         if not host and domain_key == current_domain and current_host:
             host = current_host
 
+        scheme = "https" if domain_config.https_enabled else current_scheme
         message_url = f"{scheme}://{host}{message_path}" if host else None
         serving_domains.append(
             {
@@ -465,7 +466,7 @@ def submission_status(message_id: int) -> ResponseReturnValue:
             message_id=message_id,
             current_domain=g.current_domain,
             current_host=request.host.split(":", 1)[0],
-            scheme=request.scheme,
+            current_scheme=request.scheme,
         )
 
         return render_template(

--- a/src/common/config/domain_config.py
+++ b/src/common/config/domain_config.py
@@ -32,6 +32,7 @@ class DomainConfig:
     description: Optional[str] = None
     domains: Optional[List[str]] = None  # List of hostnames that map to this domain config
     auto_archive_enabled: bool = False  # Whether to enable auto-archiving for this domain
+    https_enabled: bool = False  # Whether this domain should be served over HTTPS
 
     @property
     def allows_all_channels(self) -> bool:
@@ -98,6 +99,7 @@ class DomainManager:
                     description=settings.get("description"),
                     domains=settings.get("domains", []),
                     auto_archive_enabled=settings.get("auto_archive_enabled", False),
+                    https_enabled=settings.get("https_enabled", False),
                 )
 
                 # Map each hostname to this domain config

--- a/src/tests/blog/test_submission_status.py
+++ b/src/tests/blog/test_submission_status.py
@@ -23,6 +23,7 @@ class TestSubmissionStatusDomainLinks(unittest.TestCase):
                     channels=["misc"],
                     theme="default",
                     domains=["earlyversion.com"],
+                    https_enabled=True,
                 ),
                 "codepending": DomainConfig(
                     name="Code Pending",
@@ -38,7 +39,7 @@ class TestSubmissionStatusDomainLinks(unittest.TestCase):
             message_id=17,
             current_domain="default",
             current_host="localhost",
-            scheme="https",
+            current_scheme="https",
         )
 
         self.assertEqual([d["domain_key"] for d in links], ["default", "earlyversion"])
@@ -60,6 +61,7 @@ class TestSubmissionStatusDomainLinks(unittest.TestCase):
                     channels=["misc"],
                     theme="default",
                     domains=["earlyversion.com"],
+                    https_enabled=True,
                 ),
             }
         )
@@ -69,11 +71,50 @@ class TestSubmissionStatusDomainLinks(unittest.TestCase):
             message_id=9,
             current_domain="earlyversion",
             current_host="",
-            scheme="https",
+            current_scheme="https",
         )
 
         self.assertIsNone(links[0]["url"])
         self.assertEqual(links[1]["url"], "https://earlyversion.com/messages/9")
+
+    @patch("blog.blueprints.admin.url_for")
+    @patch("blog.blueprints.admin.get_domain_manager")
+    def test_uses_https_only_for_domains_configured_for_it(
+        self, mock_get_domain_manager, mock_url_for
+    ):
+        """Should use HTTPS only for domains marked as HTTPS-enabled."""
+        mock_url_for.return_value = "/messages/22"
+        mock_get_domain_manager.return_value = Mock(
+            domains={
+                "default": DomainConfig(name="Main Site", channels=[], theme="default"),
+                "pow3": DomainConfig(
+                    name="Pow3",
+                    channels=["tech"],
+                    theme="pow3",
+                    domains=["blog.pow3.com"],
+                    https_enabled=True,
+                ),
+                "codepending": DomainConfig(
+                    name="Code Pending",
+                    channels=["tech"],
+                    theme="default",
+                    domains=["codepending.com"],
+                    https_enabled=False,
+                ),
+            }
+        )
+
+        links = _build_submission_domain_links(
+            channel="tech",
+            message_id=22,
+            current_domain="default",
+            current_host="localhost",
+            current_scheme="http",
+        )
+
+        self.assertEqual(links[0]["url"], "http://localhost/messages/22")
+        self.assertEqual(links[1]["url"], "https://blog.pow3.com/messages/22")
+        self.assertEqual(links[2]["url"], "http://codepending.com/messages/22")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Ensure submission-status links use HTTPS only for domains that actually support it and stop HTTP requests to `blog.pow3.com` from being redirected to the wrong host.
- Centralize HTTPS behavior so both link generation and request handling follow the same domain configuration.

### Description
- Added an `https_enabled` flag to `DomainConfig` and load it from `config/domains.toml` so domains can opt in to HTTPS behavior via configuration (`src/common/config/domain_config.py`).
- Updated `config/domains.toml` to mark `earlyversion.com`, `blog.pow3.com` and `shragafeivel.com` as HTTPS-enabled.
- Changed `_build_submission_domain_links` to accept `current_scheme` and to pick `https://` when a domain's `https_enabled` is `true`, otherwise preserve the current request scheme (`src/blog/blueprints/admin.py`).
- Added an app-level HTTPS redirect in `before_request_handler` that redirects to `https://` for domains with `https_enabled` set, returning a `301` redirect (`src/atacama/server.py`).
- Adjusted the nginx HTTP redirect to preserve the incoming host (`https://$host$request_uri`) and included `blog.pow3.com` in the HTTP server block to avoid cross-host redirects (`src/atacama/nginx.conf`).
- Expanded the submission status unit tests to cover per-domain HTTPS behavior and mixed HTTPS/non-HTTPS domains (`src/tests/blog/test_submission_status.py`).

### Testing
- Ran `python3 precommit.py` and it passed.
- Ran `python3 run_tests.py --category blog --pattern '*submission_status*'` and the updated submission-status tests passed.
- Ran `python3 run_tests.py --category quick` which surfaced an existing unrelated AML parser failure (`test_handles_import_error` in `test_colorblocks`) and is not caused by these changes.
- Full `python3 run_tests.py` run encountered unrelated environment/external-service issues and pre-existing failures; the changes in this PR do not introduce new failures in the targeted blog submission-status tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfebf9e37c8327954ebd61b1a7693e)