### PR TITLE
Fix NGINX/Proxy HTTPS redirect handling and harden request-logger to avoid 500s

### DIFF
--- a/src/atacama/server.py
+++ b/src/atacama/server.py
@@ -64,7 +64,11 @@ def before_request_handler():
     domain_key = domain_manager.get_domain_for_host(host)
     domain_config = domain_manager.get_domain_config(domain_key)
 
-    if domain_config.https_enabled and request.scheme != "https":
+    # HTTPS redirects should primarily be handled by NGINX.
+    # If we are behind a proxy (X-Forwarded-Proto present), avoid performing
+    # application-level redirects that can use an incorrect host value.
+    forwarded_proto = request.headers.get("X-Forwarded-Proto")
+    if domain_config.https_enabled and request.scheme != "https" and not forwarded_proto:
         host_without_port = request.host.split(":", 1)[0]
         secure_url = f"https://{host_without_port}{request.path}"
         if request.query_string:

--- a/src/common/base/request_logger.py
+++ b/src/common/base/request_logger.py
@@ -73,7 +73,10 @@ class RequestLogger:
                 return response
 
             # Calculate request duration
-            duration = datetime.utcnow() - g.request_start_time
+            request_start_time = getattr(g, "request_start_time", None)
+            if request_start_time is None:
+                request_start_time = datetime.utcnow()
+            duration = datetime.utcnow() - request_start_time
 
             # Get user information from session
             user_info = session.get("user", {})

--- a/src/tests/atacama/test_https_redirect_and_request_logger.py
+++ b/src/tests/atacama/test_https_redirect_and_request_logger.py
@@ -1,0 +1,78 @@
+"""Tests for HTTPS redirect behavior and request logger robustness."""
+
+import unittest
+from unittest.mock import patch
+
+from flask import Flask
+
+from atacama.server import before_request_handler
+from common.base.request_logger import RequestLogger
+from common.config.domain_config import DomainConfig, ThemeConfig
+from common.config.language_config import LanguageConfig
+
+
+class HttpsRedirectTests(unittest.TestCase):
+    """Test HTTPS redirect behavior in before_request_handler."""
+
+    def setUp(self):
+        self.app = Flask(__name__)
+
+    def test_no_app_redirect_when_forwarded_proto_present(self):
+        """If NGINX provides X-Forwarded-Proto, app should not force redirect."""
+        domain_config = DomainConfig(
+            name="Pow3",
+            channels=[],
+            theme="pow3",
+            domains=["blog.pow3.com"],
+            https_enabled=True,
+        )
+        theme_config = ThemeConfig(name="Pow3", css_files=[], layout="pow3")
+        language_config = LanguageConfig(name="English", code="en", subdomains=[])
+
+        with (
+            self.app.test_request_context(
+                "/messages/22",
+                base_url="http://blog.pow3.com",
+                headers={"X-Forwarded-Proto": "http"},
+            ),
+            patch("atacama.server.get_domain_manager") as mock_domain_manager,
+            patch("atacama.server.get_language_manager") as mock_language_manager,
+        ):
+            mock_domain_manager.return_value.get_domain_for_host.return_value = "pow3"
+            mock_domain_manager.return_value.get_domain_config.return_value = domain_config
+            mock_domain_manager.return_value.get_theme_config.return_value = theme_config
+            mock_language_manager.return_value.get_language_from_host.return_value = "english"
+            mock_language_manager.return_value.get_language_config.return_value = language_config
+
+            response = before_request_handler()
+
+        self.assertIsNone(response)
+
+
+class RequestLoggerTests(unittest.TestCase):
+    """Test RequestLogger edge cases."""
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.secret_key = "test-secret"
+
+        @self.app.route("/ping")
+        def ping():
+            return "pong"
+
+    def test_missing_request_start_time_does_not_error(self):
+        """after_request should not fail when request_start_time is absent."""
+        request_logger = RequestLogger(self.app)
+        self.assertIsNotNone(request_logger)
+
+        # Simulate another before_request handler that short-circuits execution.
+        self.app.before_request_funcs[None].insert(0, lambda: ("redirect", 301))
+
+        with self.app.test_client() as client:
+            response = client.get("/ping")
+
+        self.assertEqual(response.status_code, 301)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Application was issuing incorrect HTTP→HTTPS redirects behind a reverse proxy causing cross-host redirects (e.g. blog.pow3.com → earlyversion.com).  The proxy (NGINX) should be the source of truth for scheme/host decisions. 
- A 500 error occurred in the request logging `after_request` handler when `g.request_start_time` was missing, causing uncaught `AttributeError` and failing requests.

### Description
- Changed `before_request_handler` to skip app-level HTTP→HTTPS redirects when `X-Forwarded-Proto` is present so NGINX/reverse-proxy controls scheme-aware redirects (`src/atacama/server.py`).
- Made the request-logger `after_request` handler resilient to a missing `g.request_start_time` by using `getattr` and falling back to `datetime.utcnow()` when absent (`src/common/base/request_logger.py`).
- Added regression tests that verify: (1) no Flask redirect occurs when `X-Forwarded-Proto` is supplied by the proxy, and (2) the request logger does not crash when another `before_request` short-circuits execution (`src/tests/atacama/test_https_redirect_and_request_logger.py`).

### Testing
- Ran `black` formatting on modified files and `python3 precommit.py`, both succeeded.
- Ran the project's quick test suite with `python3 run_tests.py --category quick`, which completed but reported an existing unrelated test failure in the AML parser (`test_colorblocks.TestCreateChineseAnnotation.test_handles_import_error`) that is not caused by these changes.
- Executed the new test module directly with `PYTHONPATH=src python3 -m unittest src/tests/atacama/test_https_redirect_and_request_logger.py`, and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9060080e883279771306094f4697c)