### PR TITLE
Fix HTTPS redirect loop behind NGINX proxy

### DIFF
--- a/src/atacama/server.py
+++ b/src/atacama/server.py
@@ -4,7 +4,7 @@
 
 import os
 from pathlib import Path
-from flask import Flask, request, g, redirect
+from flask import Flask, request, g
 from waitress import serve  # type: ignore[import-untyped]
 from typing import Dict, Any, Optional, List, Tuple
 
@@ -64,16 +64,13 @@ def before_request_handler():
     domain_key = domain_manager.get_domain_for_host(host)
     domain_config = domain_manager.get_domain_config(domain_key)
 
-    # HTTPS redirects should primarily be handled by NGINX.
-    # If we are behind a proxy (X-Forwarded-Proto present), avoid performing
-    # application-level redirects that can use an incorrect host value.
-    forwarded_proto = request.headers.get("X-Forwarded-Proto")
-    if domain_config.https_enabled and request.scheme != "https" and not forwarded_proto:
-        host_without_port = request.host.split(":", 1)[0]
-        secure_url = f"https://{host_without_port}{request.path}"
-        if request.query_string:
-            secure_url = f"{secure_url}?{request.query_string.decode('utf-8')}"
-        return redirect(secure_url, code=301)
+    # HTTPS redirects are handled by NGINX.
+    #
+    # The app usually receives plain HTTP from the reverse proxy
+    # (NGINX -> Waitress/Flask), so forcing an application-level HTTPS
+    # redirect can create an infinite redirect loop even for end users who
+    # already connected with HTTPS. ProxyFix still allows Flask to generate
+    # secure absolute URLs when X-Forwarded-Proto is set correctly.
 
     # Get theme configuration
     theme_key = domain_config.theme

--- a/src/tests/atacama/test_https_redirect_and_request_logger.py
+++ b/src/tests/atacama/test_https_redirect_and_request_logger.py
@@ -48,6 +48,36 @@ class HttpsRedirectTests(unittest.TestCase):
 
         self.assertIsNone(response)
 
+    def test_no_app_redirect_without_forwarded_proto(self):
+        """App should not force HTTPS redirects; NGINX is responsible for that."""
+        domain_config = DomainConfig(
+            name="Pow3",
+            channels=[],
+            theme="pow3",
+            domains=["blog.pow3.com"],
+            https_enabled=True,
+        )
+        theme_config = ThemeConfig(name="Pow3", css_files=[], layout="pow3")
+        language_config = LanguageConfig(name="English", code="en", subdomains=[])
+
+        with (
+            self.app.test_request_context(
+                "/messages/22",
+                base_url="http://blog.pow3.com",
+            ),
+            patch("atacama.server.get_domain_manager") as mock_domain_manager,
+            patch("atacama.server.get_language_manager") as mock_language_manager,
+        ):
+            mock_domain_manager.return_value.get_domain_for_host.return_value = "pow3"
+            mock_domain_manager.return_value.get_domain_config.return_value = domain_config
+            mock_domain_manager.return_value.get_theme_config.return_value = theme_config
+            mock_language_manager.return_value.get_language_from_host.return_value = "english"
+            mock_language_manager.return_value.get_language_config.return_value = language_config
+
+            response = before_request_handler()
+
+        self.assertIsNone(response)
+
 
 class RequestLoggerTests(unittest.TestCase):
     """Test RequestLogger edge cases."""


### PR DESCRIPTION
### Motivation
- Application-level HTTPS redirects caused an infinite redirect loop when NGINX terminated TLS and proxied requests to Waitress/Flask over HTTP.  HTTPS enforcement should be the reverse-proxy's responsibility.  

### Description
- Removed the app-level HTTPS redirect logic from `before_request_handler` in `src/atacama/server.py` so the app no longer issues 301 redirects to `https://...`.  
- Removed the now-unused `redirect` import from `src/atacama/server.py`.  
- Added a test `test_no_app_redirect_without_forwarded_proto` to `src/tests/atacama/test_https_redirect_and_request_logger.py` to assert the app does not perform redirects either with or without `X-Forwarded-Proto` present.  

### Testing
- Ran formatter with `black` and committed formatting changes; formatting completed successfully.  
- Ran pre-commit checks with `python3 precommit.py`; presubmit passed.  
- Ran targeted Atacama test pattern for the new/updated cases with `python3 run_tests.py --category atacama --pattern "*no_app_redirect*"`; those tests passed.  
- Ran `python3 run_tests.py --category quick` and the run surfaced an unrelated pre-existing failure (`test_handles_import_error` in `test_colorblocks`) which is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e907beafa483278d8b50831d3fc019)