### PR TITLE
Add JSON submission API: POST /api/messages and GET /api/channels

### DIFF
--- a/src/blog/blueprints/__init__.py
+++ b/src/blog/blueprints/__init__.py
@@ -11,6 +11,7 @@ from . import feeds
 from . import statistics
 from . import widgets
 from . import editor  # Three-stage blog post editor
+from . import api  # JSON submission API (POST /api/messages, GET /api/channels)
 
 # Export all blueprints for easy importing
 __all__ = ["content_bp", "quotes_bp", "feeds_bp", "statistics_bp", "widgets_bp"]

--- a/src/blog/blueprints/admin.py
+++ b/src/blog/blueprints/admin.py
@@ -8,13 +8,9 @@ from flask.typing import ResponseReturnValue
 from sqlalchemy.orm import joinedload
 
 import aml_parser
-from aml_parser.lexer import tokenize, TokenType
-from aml_parser.parser import parse
-from aml_parser.html_generator import generate_html
 from common.base.logging_config import get_logger
 from common.config.channel_config import get_channel_manager
 from common.config.domain_config import get_domain_manager
-from common.services.archive import get_archive_service
 from models import get_or_create_user
 from models.database import db
 from models.models import Email
@@ -29,6 +25,7 @@ from models.users import (
 from models.messages import get_raw_message_by_id
 from atacama.blueprints.errors import handle_error
 from atacama.decorators import navigable, require_admin, require_auth
+from blog.blueprints.shared import create_email_message, start_archive_thread
 
 logger = get_logger(__name__)
 
@@ -336,103 +333,20 @@ def handle_submit() -> ResponseReturnValue:
             # Get fresh user object within transaction
             db_user = get_or_create_user(db_session, session["user"])
 
-            # Create message
-            message = Email(subject=subject, content=content, author=db_user, channel=channel)
-
-            # Handle message chain if parent_id is provided
-            if parent_id and parent_id.strip():
-                try:
-                    parent_id = int(parent_id)
-                    parent = db_session.query(Email).get(parent_id)
-                    if parent:
-                        message.parent = parent
-                    else:
-                        logger.warning(f"Parent message {parent_id} not found")
-                except ValueError:
-                    logger.warning(f"Invalid parent_id format: {parent_id}")
-
-            # Add message to session before processing content
-            db_session.add(message)
-
-            # Process content with access to the message object and extract URLs
-            tokens = list(tokenize(content))
-            ast = parse(iter(tokens))
-
-            # Extract URLs from tokens
-            extracted_urls = []
-            for token in tokens:
-                if token.type == TokenType.URL:
-                    extracted_urls.append(token.value)
-
-            # Generate HTML content
-            message.processed_content = generate_html(ast, message=message, db_session=db_session)
-
-            message.preview_content = generate_html(
-                ast, message=message, db_session=db_session, truncated=True
+            message, extracted_urls = create_email_message(
+                db_session,
+                author=db_user,
+                subject=subject,
+                content=content,
+                channel=channel,
+                parent_id=parent_id,
             )
 
             db_session.commit()
             message_id = message.id  # Get ID before session closes
-            # Note: processed_content and extracted_urls are already available from above
 
         # Archive URLs and posts if archive service is enabled
-        archive_service = get_archive_service()
-        if archive_service:
-            try:
-                # Archive URLs from the message content in a separate thread to avoid blocking
-                import threading
-
-                def archive_content():
-                    try:
-                        # 1. Always archive URLs found in message content (in production)
-                        archived_url_count = archive_service.archive_urls_from_content(
-                            urls=extracted_urls
-                        )
-                        if archived_url_count > 0:
-                            logger.info(
-                                f"Archived {archived_url_count} URLs from message {message_id} content"
-                            )
-
-                        # 2. Archive the post itself if any domain with archiving supports this channel
-                        domain_manager = get_domain_manager()
-                        archiving_domains = []
-
-                        for domain_key, domain_config in domain_manager.domains.items():
-                            if (
-                                domain_config.auto_archive_enabled
-                                and domain_config.channel_allowed(channel)
-                            ):
-                                archiving_domains.append(domain_config)
-
-                        if archiving_domains:
-                            # Generate the message URL for archiving the post itself
-                            message_url = url_for(
-                                "content.get_message", message_id=message_id, _external=True
-                            )
-
-                            # Use the first archiving domain to avoid duplicate submissions
-                            domain_config = archiving_domains[0]
-                            archived_post_count = archive_service.archive_message_post(
-                                message_url, domain_config
-                            )
-                            if archived_post_count > 0:
-                                domain_names = [d.name for d in archiving_domains]
-                                logger.info(
-                                    f"Archived message post {message_id} for domains: {', '.join(domain_names)}"
-                                )
-                        else:
-                            logger.debug(
-                                f"No domains with archiving enabled support channel {channel}"
-                            )
-
-                    except Exception as e:
-                        logger.error(f"Error archiving content for message {message_id}: {e}")
-
-                # Start archiving in background thread
-                archive_thread = threading.Thread(target=archive_content, daemon=True)
-                archive_thread.start()
-            except Exception as e:
-                logger.error(f"Error starting archive thread for message {message_id}: {e}")
+        start_archive_thread(message_id, extracted_urls, channel)
 
         flash("Message submitted successfully!", "success")
         return redirect(url_for("admin.submission_status", message_id=message_id))

--- a/src/blog/blueprints/api.py
+++ b/src/blog/blueprints/api.py
@@ -1,0 +1,135 @@
+"""JSON submission API for external clients (e.g. the Atacama iOS app).
+
+Provides token-authenticated JSON endpoints that mirror the form-based admin
+submit flow:
+
+- ``POST /api/messages`` creates a new message from JSON.
+- ``GET /api/channels`` lists the channels the authenticated user may post to.
+
+Both reuse the shared creation/archiving helpers in :mod:`blog.blueprints.shared`
+so their behavior stays in sync with the admin form route.
+"""
+
+from flask import g, jsonify, request, url_for
+from flask.typing import ResponseReturnValue
+
+from common.base.logging_config import get_logger
+from common.config.channel_config import get_channel_manager
+from models import get_or_create_user, get_user_allowed_channels
+from models.database import db
+from atacama.blueprints.errors import handle_error
+from atacama.decorators import require_auth
+from blog.blueprints.shared import content_bp, create_email_message, start_archive_thread
+
+logger = get_logger(__name__)
+
+
+@content_bp.route("/api/messages", methods=["POST"])
+@require_auth
+def create_message_api() -> ResponseReturnValue:
+    """
+    Create a new message (Email) from JSON.
+
+    JSON equivalent of the form-based ``POST /admin/submit`` route, sharing the
+    same creation and archiving pipeline. The author is resolved from ``g.user``,
+    which :func:`require_auth` populates from either an auth token (mobile/API) or
+    a session.
+
+    Request JSON:
+        - subject: The message subject (required)
+        - content: The full AML content (required)
+        - channel: Channel to post to (optional, defaults to the configured default)
+        - parent_id: Optional parent message id for chains
+
+    :return: JSON with new message id, url, and rendered HTML; HTTP 201 on success
+    :raises: HTTP 400 if the request body is not JSON
+    :raises: HTTP 422 if subject or content is missing
+    :raises: HTTP 500 if creation fails
+    """
+    if not request.is_json:
+        return handle_error("400", "Bad Request", "Request must be JSON")
+
+    data = request.get_json(silent=True)
+    if data is None:
+        return handle_error("400", "Bad Request", "Request must be JSON")
+
+    channel_manager = get_channel_manager()
+
+    subject = (data.get("subject") or "").strip()
+    content = (data.get("content") or "").strip()
+    channel = data.get("channel") or channel_manager.default_channel
+    if isinstance(channel, str):
+        channel = channel.strip() or channel_manager.default_channel
+    parent_id = data.get("parent_id")
+
+    if not subject or not content:
+        return handle_error("422", "Validation Error", "Subject and content are required")
+
+    try:
+        with db.session() as db_session:
+            # Re-fetch the user inside this session to avoid detached-instance issues
+            # (g.user may come from a token and a now-closed session).
+            db_user = get_or_create_user(db_session, {"email": g.user.email, "name": g.user.name})
+
+            message, extracted_urls = create_email_message(
+                db_session,
+                author=db_user,
+                subject=subject,
+                content=content,
+                channel=channel,
+                parent_id=parent_id,
+            )
+
+            db_session.commit()
+            message_id = message.id
+            processed_content = message.processed_content
+
+        # Archive URLs and posts if archive service is enabled
+        start_archive_thread(message_id, extracted_urls, channel)
+
+        return (
+            jsonify(
+                {
+                    "id": message_id,
+                    "url": url_for("content.get_message", message_id=message_id, _external=True),
+                    "processed_content": processed_content,
+                }
+            ),
+            201,
+        )
+
+    except Exception as e:
+        logger.error(f"Error creating message via API: {str(e)}")
+        return handle_error("500", "Submission Error", "Failed to submit message", str(e))
+
+
+@content_bp.route("/api/channels", methods=["GET"])
+@require_auth
+def list_channels_api() -> ResponseReturnValue:
+    """
+    List the channels the authenticated user may post to, for a channel picker.
+
+    Honors system access levels and the user's channel preferences via
+    :func:`get_user_allowed_channels`.
+
+    :return: JSON with the list of channels and the default channel
+    """
+    channel_manager = get_channel_manager()
+
+    allowed = get_user_allowed_channels(g.user)
+
+    channels = []
+    for name in allowed:
+        config = channel_manager.get_channel_config(name)
+        if not config:
+            continue
+        channels.append(
+            {
+                "name": name,
+                "display_name": config.get_display_name(),
+                "group": config.group,
+                "requires_auth": config.requires_auth,
+            }
+        )
+
+    return jsonify({"channels": channels, "default": channel_manager.default_channel})

--- a/src/blog/blueprints/shared.py
+++ b/src/blog/blueprints/shared.py
@@ -1,7 +1,19 @@
-"""Shared blueprints for blog functionality."""
+"""Shared blueprints and helpers for blog functionality."""
 
-from flask import Blueprint
 import os
+import threading
+
+from flask import Blueprint, url_for
+
+from aml_parser.lexer import tokenize, TokenType
+from aml_parser.parser import parse
+from aml_parser.html_generator import generate_html
+from common.base.logging_config import get_logger
+from common.config.domain_config import get_domain_manager
+from common.services.archive import get_archive_service
+from models.models import Email
+
+logger = get_logger(__name__)
 
 # Get the blog module directory (parent of blueprints/)
 blog_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -39,3 +51,105 @@ widgets_bp = Blueprint(
     template_folder=os.path.join(blog_dir, "templates"),
     static_folder=os.path.join(blog_dir, "static"),
 )
+
+
+def create_email_message(db_session, *, author, subject, content, channel, parent_id=None):
+    """
+    Create and persist an :class:`Email` message from raw AML content.
+
+    Runs the shared tokenize -> parse -> generate_html pipeline used by both the
+    admin form submit route and the JSON API. The caller owns the surrounding
+    ``db.session()``; this function adds and processes the message but does not
+    commit.
+
+    :param db_session: Active SQLAlchemy session
+    :param author: User model instance to set as the message author
+    :param subject: Message subject/title
+    :param content: Raw AML markup
+    :param channel: Channel name to post into
+    :param parent_id: Optional parent message id for threaded chains. Invalid or
+                      unknown ids are logged and ignored.
+    :return: Tuple of (message, extracted_urls)
+    """
+    message = Email(subject=subject, content=content, author=author, channel=channel)
+
+    # Handle message chain if parent_id is provided
+    if parent_id is not None and str(parent_id).strip():
+        try:
+            parent_id = int(parent_id)
+            parent = db_session.query(Email).get(parent_id)
+            if parent:
+                message.parent = parent
+            else:
+                logger.warning(f"Parent message {parent_id} not found")
+        except (ValueError, TypeError):
+            logger.warning(f"Invalid parent_id format: {parent_id}")
+
+    # Add message to session before processing content
+    db_session.add(message)
+
+    # Process content with access to the message object and extract URLs
+    tokens = list(tokenize(content))
+    ast = parse(iter(tokens))
+
+    extracted_urls = [token.value for token in tokens if token.type == TokenType.URL]
+
+    message.processed_content = generate_html(ast, message=message, db_session=db_session)
+    message.preview_content = generate_html(
+        ast, message=message, db_session=db_session, truncated=True
+    )
+
+    return message, extracted_urls
+
+
+def start_archive_thread(message_id, extracted_urls, channel):
+    """
+    Kick off background archiving for a newly created message, if archiving is
+    enabled. Archives both URLs found in the content and (for domains configured
+    with auto-archiving) the message post itself. Never raises.
+
+    :param message_id: ID of the persisted message
+    :param extracted_urls: URLs extracted from the message content
+    :param channel: Channel the message was posted to
+    """
+    archive_service = get_archive_service()
+    if not archive_service:
+        return
+
+    def archive_content():
+        try:
+            # 1. Always archive URLs found in message content (in production)
+            archived_url_count = archive_service.archive_urls_from_content(urls=extracted_urls)
+            if archived_url_count > 0:
+                logger.info(f"Archived {archived_url_count} URLs from message {message_id} content")
+
+            # 2. Archive the post itself if any domain with archiving supports this channel
+            domain_manager = get_domain_manager()
+            archiving_domains = [
+                domain_config
+                for domain_config in domain_manager.domains.values()
+                if domain_config.auto_archive_enabled and domain_config.channel_allowed(channel)
+            ]
+
+            if archiving_domains:
+                message_url = url_for("content.get_message", message_id=message_id, _external=True)
+                # Use the first archiving domain to avoid duplicate submissions
+                archived_post_count = archive_service.archive_message_post(
+                    message_url, archiving_domains[0]
+                )
+                if archived_post_count > 0:
+                    domain_names = [d.name for d in archiving_domains]
+                    logger.info(
+                        f"Archived message post {message_id} for domains: {', '.join(domain_names)}"
+                    )
+            else:
+                logger.debug(f"No domains with archiving enabled support channel {channel}")
+
+        except Exception as e:
+            logger.error(f"Error archiving content for message {message_id}: {e}")
+
+    try:
+        archive_thread = threading.Thread(target=archive_content, daemon=True)
+        archive_thread.start()
+    except Exception as e:
+        logger.error(f"Error starting archive thread for message {message_id}: {e}")

--- a/src/tests/blog/test_submit_api.py
+++ b/src/tests/blog/test_submit_api.py
@@ -1,0 +1,185 @@
+"""Tests for the JSON submission API: POST /api/messages and GET /api/channels."""
+
+import unittest
+from datetime import datetime
+
+from atacama.server import create_app
+from models.database import db
+from models.models import User, UserToken, Email
+
+
+class SubmitApiTests(unittest.TestCase):
+    """Test cases for the token-authenticated JSON submission endpoints."""
+
+    def setUp(self):
+        """Set up test application with in-memory database and an auth token."""
+        self.app = create_app(testing=True)
+        self.app.config.update(
+            {
+                "TESTING": True,
+                "SERVER_NAME": "test.local",
+            }
+        )
+        self.client = self.app.test_client()
+        self.token = "api-test-token-12345"
+        self.user_email = "api@example.com"
+
+        with self.app.app_context():
+            with db.session() as db_session:
+                user = User(email=self.user_email, name="API User")
+                db_session.add(user)
+                db_session.flush()
+                db_session.add(
+                    UserToken(user_id=user.id, token=self.token, created_at=datetime.utcnow())
+                )
+                db_session.commit()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        db.cleanup()
+
+    @property
+    def auth_headers(self):
+        return {"Authorization": f"Bearer {self.token}"}
+
+    # --- POST /api/messages -------------------------------------------------
+
+    def test_create_message_requires_auth(self):
+        """Unauthenticated requests are rejected with 401 UNAUTHORIZED."""
+        response = self.client.post("/api/messages", json={"subject": "Hi", "content": "Body"})
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.get_json().get("code"), "UNAUTHORIZED")
+
+    def test_create_message_rejects_non_json(self):
+        """Non-JSON bodies are rejected with 400."""
+        response = self.client.post(
+            "/api/messages",
+            data="not json",
+            content_type="text/plain",
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_message_requires_subject_and_content(self):
+        """Missing subject or content yields 422."""
+        response = self.client.post(
+            "/api/messages",
+            json={"subject": "", "content": "Body"},
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, 422)
+
+        response = self.client.post(
+            "/api/messages",
+            json={"subject": "Subject only"},
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_message_success(self):
+        """A valid request creates a message and returns id, url, and HTML."""
+        response = self.client.post(
+            "/api/messages",
+            json={"subject": "On deserts", "content": "Main text here.", "channel": "misc"},
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, 201)
+        data = response.get_json()
+        self.assertIn("id", data)
+        self.assertIn("processed_content", data)
+        self.assertTrue(data["url"].endswith(f"/messages/{data['id']}"))
+
+        # Verify the message was actually persisted with the right author/channel.
+        with self.app.app_context():
+            with db.session() as db_session:
+                message = db_session.query(Email).get(data["id"])
+                self.assertIsNotNone(message)
+                self.assertEqual(message.subject, "On deserts")
+                self.assertEqual(message.channel, "misc")
+                self.assertEqual(message.author.email, self.user_email)
+                self.assertTrue(message.processed_content)
+                self.assertTrue(message.preview_content)
+
+    def test_create_message_defaults_channel(self):
+        """Omitting channel falls back to the default channel."""
+        response = self.client.post(
+            "/api/messages",
+            json={"subject": "No channel", "content": "Body"},
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, 201)
+        data = response.get_json()
+        with self.app.app_context():
+            with db.session() as db_session:
+                message = db_session.query(Email).get(data["id"])
+                self.assertEqual(message.channel, "private")  # default_channel
+
+    def test_create_message_links_parent(self):
+        """A valid parent_id links the new message into a chain."""
+        parent = self.client.post(
+            "/api/messages",
+            json={"subject": "Parent", "content": "Parent body", "channel": "misc"},
+            headers=self.auth_headers,
+        )
+        parent_id = parent.get_json()["id"]
+
+        child = self.client.post(
+            "/api/messages",
+            json={
+                "subject": "Child",
+                "content": "Child body",
+                "channel": "misc",
+                "parent_id": parent_id,
+            },
+            headers=self.auth_headers,
+        )
+        self.assertEqual(child.status_code, 201)
+        child_id = child.get_json()["id"]
+        with self.app.app_context():
+            with db.session() as db_session:
+                message = db_session.query(Email).get(child_id)
+                self.assertEqual(message.parent_id, parent_id)
+
+    def test_create_message_ignores_invalid_parent(self):
+        """An unknown/invalid parent_id is ignored, not fatal."""
+        response = self.client.post(
+            "/api/messages",
+            json={"subject": "Orphan", "content": "Body", "channel": "misc", "parent_id": 999999},
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, 201)
+        with self.app.app_context():
+            with db.session() as db_session:
+                message = db_session.query(Email).get(response.get_json()["id"])
+                self.assertIsNone(message.parent_id)
+
+    # --- GET /api/channels --------------------------------------------------
+
+    def test_list_channels_requires_auth(self):
+        """Unauthenticated requests are rejected with 401."""
+        response = self.client.get("/api/channels")
+        self.assertEqual(response.status_code, 401)
+
+    def test_list_channels_shape_and_filtering(self):
+        """Returns allowed channels with the expected shape and a default."""
+        response = self.client.get("/api/channels", headers=self.auth_headers)
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+
+        self.assertEqual(data["default"], "private")
+        self.assertIsInstance(data["channels"], list)
+
+        by_name = {c["name"]: c for c in data["channels"]}
+        # Public channel is available to every authenticated user.
+        self.assertIn("misc", by_name)
+        misc = by_name["misc"]
+        self.assertEqual(misc["display_name"], "Miscellany")
+        self.assertEqual(misc["group"], "General")
+        self.assertFalse(misc["requires_auth"])
+
+        # Restricted, admin-only channel is excluded for a regular user.
+        self.assertNotIn("politics", by_name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the two backend endpoints the Atacama iOS app needs, both on the existing content_bp in submit.py (no server.py change):

- POST /api/messages: create an Email from JSON, mirroring the form-based /submit route. Resolves the author from g.user (token auth has no Flask session), re-fetching the user inside the new db.session() to avoid detached-instance issues. Returns 201 with {id, url, processed_content}; 400 for non-JSON, 422 for missing subject/content.
- GET /api/channels: lists channels the user may post to via get_user_allowed_channels (honors access levels and channel preferences), with display_name/group/requires_auth and the default channel.

Refactors the shared AML pipeline out of handle_submit into create_email_message(...) and the background archiving into _start_archive_thread(...) so the form route and the JSON route share one implementation; the form route's behavior is unchanged.

Adds src/tests/blog/test_submit_api.py covering auth, validation, channel defaulting, parent linking, and channel filtering.