### PR TITLE
Sync .agents/ ecosystem docs across repos

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,12 +1,25 @@
 # .agents Directory
 
-This directory contains Claude Code configuration and context files.
+This directory contains agent-facing configuration and ecosystem context docs.
+Its core purpose is to give agents a lightweight, predictable summary of what the
+sibling repositories are for, so references between projects can be understood
+without guessing where code lives.
 
 ## Structure
 
-- **peer-repo/** - Status summaries of related repositories in the project ecosystem
-  - `atacama-status.md` - Atacama CMS and backend infrastructure
+- **README.md** - Orientation for `.agents` usage and the maintenance workflow
+- **peer-repo/** - Status summaries of the repositories in the ecosystem
+  - `README.md` - Status file template and update checklist
+  - `newslettr-status.md` - Newslettr Go batched-publishing system
+  - `atacama-status.md` - Atacama CMS/blog and Trakaido Stats API backend
+  - `trakaido-status.md` - Trakaido language-learning app clients
   - `greenland-status.md` - Greenland linguistic database system
-  - `trakaido-status.md` - Trakaido language learning applications
+  - `trakaido-prodconfig-status.md` - Production deployment configuration
+- **scripts/** - Validation tooling for `.agents` documentation
+  - `validate_agents_docs.sh` - Checks required files/sections/headings
+- **commands/** - (optional, repo-specific) usage notes for command-line tools or
+  local APIs; e.g. greenland's `lms.md` covers the LM Studio CLI and API.
 
-These files provide AI assistants with context about how this repository relates to other parts of the broader project ecosystem.
+The `peer-repo/` files are kept identical across every repo in the ecosystem.
+Keep them concise and up to date when workflow or ownership boundaries change,
+and run `scripts/validate_agents_docs.sh` after edits.

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,45 @@
+# Ecosystem Agents Directory
+
+This directory holds agent-facing documentation for this repo and cross-repo
+context for the wider project ecosystem. It is a lightweight summary of what the
+sibling repositories are for, so agents can understand references between projects
+before making assumptions about where code lives.
+
+## What lives here
+
+- **AGENTS.md** - Scope + structure notes for this folder
+- **README.md** - This file; quick orientation and maintenance workflow
+- **peer-repo/** - High-level status snapshots for the ecosystem repositories
+  - `newslettr-status.md` - Go batched-publishing system (AML)
+  - `atacama-status.md` - CMS/blog backend and the Trakaido Stats API
+  - `trakaido-status.md` - App clients (React / Swift / Kotlin) and content consumer
+  - `greenland-status.md` - Linguistic data generation and export pipeline
+  - `trakaido-prodconfig-status.md` - Production deployment config
+  - `README.md` - Status file template + update checklist
+- **scripts/** - Lightweight helpers for validating `.agents` docs
+- **commands/** - (optional, repo-specific) CLI / local-API usage notes
+
+## The ecosystem at a glance
+
+- **greenland** generates linguistic data → **trakaido** consumes it across its
+  React/Swift/Kotlin clients.
+- **atacama** hosts the Trakaido Stats API (cloud sync, auth) and is also a
+  CMS/blog publishing platform with an AML markup language.
+- **newslettr** is a separate Go batched-publishing system that shares the AML
+  concept with Atacama.
+- **trakaido-prodconfig** is the deployment layer: it pins ports, domains,
+  systemd units, and NGINX routing for the services above on the shared server.
+
+## Maintenance workflow for `.agents`
+
+1. Update the relevant `peer-repo/*-status.md` file.
+2. Keep the first heading as `# <Repo> - Current Status`.
+3. Run the validation helper:
+
+   ```bash
+   bash .agents/scripts/validate_agents_docs.sh
+   ```
+
+4. Sync the same `peer-repo/` content to the other repos (these files are meant
+   to be identical everywhere), and commit with a message that references
+   `.agents`.

--- a/.agents/peer-repo/README.md
+++ b/.agents/peer-repo/README.md
@@ -1,0 +1,32 @@
+# Peer Repo Status Files
+
+These files summarize the current state of the repositories that make up the
+project ecosystem. They are synced identically across every participating repo so
+that, from inside any one repo, an agent can orient on the others.
+
+## Required files
+
+- `newslettr-status.md` - Go batched-publishing system (AML; Reader/Publisher/Admin)
+- `atacama-status.md` - CMS/blog, React widgets, and the Trakaido Stats API backend
+- `trakaido-status.md` - Language-learning app clients (React / Swift / Kotlin)
+- `greenland-status.md` - Linguistic database and WireWord data generation pipeline
+- `trakaido-prodconfig-status.md` - Production deployment config (systemd, NGINX, env)
+
+## Required structure
+
+Each status file should include:
+
+1. Title: `# <Repo> - Current Status`
+2. `## Repository Overview`
+3. `## Technical Architecture` (or equivalent)
+4. `## Development Workflow` (or equivalent)
+5. `## Current State`
+
+## Update checklist
+
+- Prefer short, factual updates over speculative roadmap notes.
+- Mention where code for each platform actually lives.
+- Call out build/test entry points when known.
+- Keep sections skimmable with headings and bullets.
+- When you change a status file, sync the same content to every repo's
+  `.agents/peer-repo/` (these files are intended to be identical everywhere).

--- a/.agents/peer-repo/newslettr-status.md
+++ b/.agents/peer-repo/newslettr-status.md
@@ -1,0 +1,78 @@
+# Newslettr - Current Status
+
+## Repository Overview
+
+**Newslettr** is a small, self-hosted publishing system for **batched** updates,
+written in **Go**. Authors stage posts, links, and calendar entries throughout
+the week; when ready, they assemble a single **Newsletter** and send it — one
+considered digest rather than a stream of notifications. The newsletter is the
+unit of output (see `PHILOSOPHY.md`).
+
+Posts are written in **AML**, a color/semantic markup language conceptually
+shared with Atacama. Newslettr parses AML into an AST and renders safe HTML,
+storing both the raw source and the rendered output (`STYLE.md`).
+
+## Architecture
+
+Newslettr is split into separately-served sections, each its own binary with a
+scoped session cookie and static asset tree. Cookies are **not** interchangeable
+between sections.
+
+| Section       | Binary                     | Default port | Audience                      |
+| ------------- | -------------------------- | ------------ | ----------------------------- |
+| **Reader**    | `cmd/newslettr-reader`     | `2201`       | Subscribers and the public    |
+| **Publisher** | `cmd/newslettr-publisher`  | `2202`       | Authors writing content       |
+| **Admin**     | `cmd/newslettr-admin`      | `2203`       | Operators and moderators      |
+| **MCP**       | `cmd/newslettr-mcp`        | `2204`       | Read-only project/context API |
+| **Worker**    | `cmd/newslettr-worker`     | —            | Background jobs (skeleton)    |
+
+Supporting binaries live alongside these: `newslettr-seed` (idempotent admin +
+starter topics), `newslettr-load-domains` (loads domain/topic config into
+Postgres), `newslettr-dev`, and importers (`newslettr-import-atacama`,
+`newslettr-import-git`, `newslettr-import-substack`).
+
+## Technical Architecture
+
+- **Language**: Go (module `newslettr`, Go 1.25+).
+- **Database**: PostgreSQL via `pgx/v5` (shared Supabase Postgres `newslettr`
+  schema in development).
+- **Views**: rendered through **templ** components in `internal/views/`
+  (`*.templ` source compiled to generated `*_templ.go` — never hand-edit the
+  generated files; regenerate per-file).
+- **Internal packages** (`internal/`): `aml` (markup pipeline), `app` (per-section
+  HTTP apps and routes), `auth`/`sessions`/`csrf` (security), `store`/`models`
+  (data layer), `newsletter`/`digest` (assembly + send), `calendar`, `mailer`,
+  `llm`, `mcpserver`, and importers (`atacamaimport`, `gitimport`,
+  `substackimport`).
+- **MCP server**: read-only, low-token, store-backed; stdio-first with optional
+  local HTTP (`NEWSLETTR_MCP_TRANSPORT=http`, default `127.0.0.1:2204`).
+
+## Development Workflow
+
+- `go` is not on the default non-login PATH; use `/usr/local/go/bin/go`. The
+  templ generator is `$HOME/go/bin/templ` (keep version in sync with `go.mod`).
+- `./run_dev_server.sh` builds and runs Reader/Publisher/Admin against the shared
+  Postgres schema after seeding. Seed admin: `admin@newslettr.local` /
+  `newslettr-dev`.
+- Standard checks: `go build ./...`, `go test ./...`. Test views by rendering
+  components directly and exercise routes through the in-process
+  `internal/app/apptest` harness; do **not** write login/session-based HTTP tests
+  against a running server.
+- Reference docs in the repo: `README.md`, `PHILOSOPHY.md`, `STYLE.md`,
+  `API.md`, `BACKEND.md`, `MCP.md`, `GO_IMPLEMENTATION_PLAN.md`.
+
+## Integration with Ecosystem
+
+- Shares the **AML** markup concept with **Atacama** and can import legacy
+  content from it (`newslettr-import-atacama`).
+- Deployed alongside the other ecosystem services on the shared DigitalOcean
+  server; **trakaido-prodconfig** owns the systemd units, NGINX routing, and
+  environment templates for the Reader/Publisher/Admin binaries
+  (`shragafeivel.com`, `blog.pow3.com`, `earlyversion.com`).
+
+## Current State
+
+The core servers (Reader, Publisher, Admin), data model, auth/sessions, AML
+pipeline, and the mobile JSON/token API are implemented. Remaining work centers
+on calendar import and the forward-looking parts of newsletter assembly
+(see `BACKEND.md`). The Worker binary is currently a skeleton.

--- a/.agents/peer-repo/trakaido-prodconfig-status.md
+++ b/.agents/peer-repo/trakaido-prodconfig-status.md
@@ -1,0 +1,70 @@
+# Trakaido Prodconfig - Current Status
+
+## Repository Overview
+
+**trakaido-prodconfig** holds the shared **production configuration and
+deployment tooling** for the DigitalOcean server that hosts the ecosystem's
+services. It is not an application: it is the glue that defines how the other
+repositories are deployed, routed, and run in production. When a task involves
+ports, domains, systemd units, NGINX routing, or where a service's code lives on
+the server, this repo is the source of truth.
+
+## What it manages
+
+The repo maps each running service to its user, port, public domain, and source
+repository. Services it deploys include:
+
+- **newslettr-reader / -publisher / -admin** (ports 2201/2202/2203) →
+  `shragafeivel.com`, `blog.pow3.com`, `earlyversion.com`, `earlyversion.com/admin/`
+  — code from the **newslettr** repo.
+- **atacama-web** (legacy blog, port 5000, rollback only) and **spaceship**
+  (port 8998, `spaceship.computer`) — code from the **atacama** repo.
+- **trakaido-api** (port 6370, `*.trakaido.com` app API) — served from an
+  Atacama checkout; **trakaido-landing** (port 6010, `trakaido.com`).
+- **barsukas** (port 5555, testing) — the **greenland** web UI.
+- Other unrelated tenants on the same box (pow3web, dssres, yevaud) and the
+  metrics/monitoring host (Prometheus + Perses).
+
+Trakaido production domains fan out to landing (6010), per-language production
+and staging app static builds (API 6370), and admin-authenticated reverse
+proxies for metrics dashboards.
+
+## Technical Architecture
+
+Plain configuration, organized by concern:
+
+```
+prodconfig/
+├── README.md
+├── services/     # systemd service files
+├── nginx/        # nginx site configs
+├── env/          # environment file templates (*.env.example)
+├── monitoring/   # Prometheus / Perses config
+├── sudoers/      # sudoers entries for deploy users
+└── scripts/      # deploy-all.sh, status.sh, verify.sh
+```
+
+## Development Workflow
+
+- **Secrets are never committed.** Environment files hold secrets and live on the
+  server under each service user's `keys/` directory; the repo ships only
+  `*.env.example` templates.
+- Deployment helpers live in `scripts/` (`deploy-all.sh`, `status.sh`,
+  `verify.sh` for comprehensive verification).
+- Service files and NGINX configs are deployed to the server; config changes
+  generally require a service restart.
+
+## Integration with Ecosystem
+
+This repo is the deployment layer beneath **newslettr**, **atacama**,
+**trakaido**, and **greenland** (barsukas). It does not contain application
+logic; instead it pins where each app runs, on which port, behind which domain,
+and as which system user. Cross-repo questions about production topology — "which
+domain serves the Trakaido API?", "where does newslettr's admin route?" — are
+answered here.
+
+## Current State
+
+An actively maintained, configuration-only repository tracking the live
+DigitalOcean deployment. It reflects the current production topology of the
+ecosystem's services and is updated as services, ports, or domains change.

--- a/.agents/scripts/validate_agents_docs.sh
+++ b/.agents/scripts/validate_agents_docs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PEER_DIR="$ROOT_DIR/peer-repo"
+
+required_files=(
+  "newslettr-status.md"
+  "atacama-status.md"
+  "trakaido-status.md"
+  "greenland-status.md"
+  "trakaido-prodconfig-status.md"
+)
+
+required_sections=(
+  "## Repository Overview"
+  "## Current State"
+)
+
+status=0
+
+for file in "${required_files[@]}"; do
+  path="$PEER_DIR/$file"
+  if [[ ! -f "$path" ]]; then
+    echo "[ERROR] Missing required file: $path"
+    status=1
+    continue
+  fi
+
+  if ! head -n 1 "$path" | rg -q '^# .+ - Current Status$'; then
+    echo "[ERROR] Invalid title format in $file (expected '# <Repo> - Current Status')"
+    status=1
+  fi
+
+  for section in "${required_sections[@]}"; do
+    if ! rg -q "^${section}$" "$path"; then
+      echo "[ERROR] Missing section '${section}' in $file"
+      status=1
+    fi
+  done
+
+done
+
+if [[ $status -eq 0 ]]; then
+  echo "[OK] .agents documentation structure is valid"
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary

Syncs this repo's `.agents/` directory with the rest of the ecosystem. The `.agents/peer-repo/` summaries are kept byte-identical across all five repos so an agent working in any one repo can orient on the others.

## What's in this PR

- **Two new peer-repo status files** (previously undescribed anywhere): `newslettr-status.md` and `trakaido-prodconfig-status.md`.
- **Standardized the shared structure** to match the other repos:
  - `AGENTS.md` updated to the richer, generalized version
  - Added top-level `README.md`, `peer-repo/README.md` template, and `scripts/validate_agents_docs.sh` (now requires all five status files)
- The existing `atacama`/`greenland`/`trakaido` status files were already in sync and are unchanged in content.

## Validation

`bash .agents/scripts/validate_agents_docs.sh` → `[OK] .agents documentation structure is valid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6tx8imm7NyFpSerD7UFE7)_