### PR TITLE
Add POST /api/links for the iOS Share Extension

### DIFF
--- a/src/blog/blueprints/api.py
+++ b/src/blog/blueprints/api.py
@@ -4,11 +4,14 @@ Provides token-authenticated JSON endpoints that mirror the form-based admin
 submit flow:
 
 - ``POST /api/messages`` creates a new message from JSON.
+- ``POST /api/links`` saves a shared link as a message (iOS Share Extension).
 - ``GET /api/channels`` lists the channels the authenticated user may post to.
 
-Both reuse the shared creation/archiving helpers in :mod:`blog.blueprints.shared`
+All reuse the shared creation/archiving helpers in :mod:`blog.blueprints.shared`
 so their behavior stays in sync with the admin form route.
 """
+
+from urllib.parse import urlparse
 
 from flask import g, jsonify, request, url_for
 from flask.typing import ResponseReturnValue
@@ -50,7 +53,12 @@ def client_config_api() -> ResponseReturnValue:
             # strip the trailing slash so the client can append "/api/...".
             "api_base": request.url_root.rstrip("/"),
             "auth": {"type": "oauth", "login_path": "/login"},
-            "capabilities": {"preview": True, "messages": True, "channels": True},
+            "capabilities": {
+                "preview": True,
+                "messages": True,
+                "channels": True,
+                "links": True,
+            },
         }
     )
 
@@ -132,6 +140,142 @@ def create_message_api() -> ResponseReturnValue:
     except Exception as e:
         logger.error(f"Error creating message via API: {str(e)}")
         return handle_error("500", "Submission Error", "Failed to submit message", str(e))
+
+
+def _validate_link_fields(url, title, quote, comment):
+    """
+    Apply the shared-link field limits (mirrors newslettr's ``validateAPILink``).
+
+    Only the URL is required — the share flow backfills the title and leaves
+    quote and comment optional — so a one-tap share succeeds.
+
+    :return: An error message string, or ``None`` when the fields are acceptable
+    """
+    if not url:
+        return "URL is required"
+    if len(url) > 2000:
+        return "URL must be at most 2,000 characters"
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return "Enter a valid http or https URL"
+    if len(title) > 200:
+        return "Title must be at most 200 characters"
+    if len(quote) > 2000:
+        return "Quote must be at most 2,000 characters"
+    if len(comment) > 2000:
+        return "Comment must be at most 2,000 characters"
+    return None
+
+
+@content_bp.route("/api/links", methods=["POST"])
+@require_auth
+def create_link_api() -> ResponseReturnValue:
+    """
+    Save a shared link (URL plus optional title/quote/comment) as a new message.
+
+    This backs the atacama-ios Share Extension and mirrors the newslettr
+    backend's ``POST /api/links`` contract so one client targets either backend.
+    Atacama has no separate link model, so the link becomes a regular message:
+    the comment leads, the quote renders as a ``<quote>`` block, and the URL sits
+    on its own line (auto-linked, and archived by the shared archive pipeline).
+
+    Request JSON:
+        - url: The shared link (required, http/https)
+        - title: Message subject (optional, defaults to the URL's host)
+        - topic: Channel to post to (alias ``channel``; optional, defaults to
+          the configured default)
+        - quote: Pulled excerpt (optional)
+        - comment: The sharer's note (optional)
+        - draft: Must be false/omitted — atacama has no unpublished drafts
+
+    :return: JSON describing the saved link; HTTP 201 on success
+    :raises: HTTP 400 if the request body is not JSON
+    :raises: HTTP 422 if the URL is missing/invalid, a field exceeds its limit,
+             the channel is unknown, or ``draft`` is true
+    :raises: HTTP 500 if creation fails
+    """
+    if not request.is_json:
+        return handle_error("400", "Bad Request", "Request must be JSON")
+
+    data = request.get_json(silent=True)
+    if data is None:
+        return handle_error("400", "Bad Request", "Request must be JSON")
+
+    channel_manager = get_channel_manager()
+
+    url = (data.get("url") or "").strip()
+    title = (data.get("title") or "").strip()
+    quote = (data.get("quote") or "").strip()
+    comment = (data.get("comment") or "").strip()
+    channel = (data.get("topic") or data.get("channel") or "").strip()
+
+    if not title and url:
+        title = urlparse(url).hostname or url
+
+    error = _validate_link_fields(url, title, quote, comment)
+    if error:
+        return handle_error("422", "Validation Error", error)
+
+    if data.get("draft"):
+        return handle_error(
+            "422",
+            "Validation Error",
+            "This server does not support saving drafts; turn off 'Save as draft'",
+        )
+
+    if not channel:
+        channel = channel_manager.default_channel
+    if not channel_manager.get_channel_config(channel):
+        return handle_error("422", "Validation Error", f"Unknown channel: {channel}")
+
+    # Compose the message body: comment first (the sharer's voice), then the
+    # quoted excerpt, then the bare URL so the lexer extracts and archives it.
+    paragraphs = []
+    if comment:
+        paragraphs.append(comment)
+    if quote:
+        paragraphs.append(f"<quote> {quote}")
+    paragraphs.append(url)
+    content = "\n\n".join(paragraphs)
+
+    try:
+        with db.session() as db_session:
+            db_user = get_or_create_user(db_session, {"email": g.user.email, "name": g.user.name})
+
+            message, extracted_urls = create_email_message(
+                db_session,
+                author=db_user,
+                subject=title,
+                content=content,
+                channel=channel,
+            )
+
+            db_session.commit()
+            message_id = message.id
+
+        start_archive_thread(message_id, extracted_urls, channel)
+
+        channel_config = channel_manager.get_channel_config(channel)
+        return (
+            jsonify(
+                {
+                    "id": message_id,
+                    "url": url,
+                    "domain": urlparse(url).hostname,
+                    "title": title,
+                    "topic": {"id": channel, "name": channel_config.get_display_name()},
+                    "is_draft": False,
+                    "message_url": url_for(
+                        "content.get_message", message_id=message_id, _external=True
+                    ),
+                }
+            ),
+            201,
+        )
+
+    except Exception as e:
+        logger.error(f"Error creating link via API: {str(e)}")
+        return handle_error("500", "Submission Error", "Failed to save link", str(e))
 
 
 @content_bp.route("/api/channels", methods=["GET"])

--- a/src/models/quotes.py
+++ b/src/models/quotes.py
@@ -325,10 +325,14 @@ def save_quotes(quotes: List[Dict], message: Email, db_session: Session) -> None
             if not is_valid:
                 raise QuoteValidationError(error)
 
-            # Check for existing identical quote
-            existing_quote = (
-                db_session.query(Quote).filter(Quote.text == quote_data["text"]).first()
-            )
+            # Check for existing identical quote. Suppress autoflush: this runs
+            # mid-render from generate_html, while the owning Email is pending
+            # in the session with its NOT NULL processed_content still unset,
+            # and a query-invoked flush would fail on that constraint.
+            with db_session.no_autoflush:
+                existing_quote = (
+                    db_session.query(Quote).filter(Quote.text == quote_data["text"]).first()
+                )
 
             if existing_quote:
                 message.quotes.append(existing_quote)

--- a/src/tests/blog/test_links_api.py
+++ b/src/tests/blog/test_links_api.py
@@ -1,0 +1,185 @@
+"""Tests for the shared-link API: POST /api/links (backs the iOS Share Extension)."""
+
+import unittest
+from datetime import datetime
+
+from atacama.server import create_app
+from models.database import db
+from models.models import User, UserToken, Email
+
+
+class LinksApiTests(unittest.TestCase):
+    """Test cases for the token-authenticated shared-link endpoint."""
+
+    def setUp(self):
+        """Set up test application with in-memory database and an auth token."""
+        self.app = create_app(testing=True)
+        self.app.config.update(
+            {
+                "TESTING": True,
+                "SERVER_NAME": "test.local",
+            }
+        )
+        self.client = self.app.test_client()
+        self.token = "links-test-token-12345"
+        self.user_email = "links@example.com"
+
+        with self.app.app_context():
+            with db.session() as db_session:
+                user = User(email=self.user_email, name="Links User")
+                db_session.add(user)
+                db_session.flush()
+                db_session.add(
+                    UserToken(user_id=user.id, token=self.token, created_at=datetime.utcnow())
+                )
+                db_session.commit()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        db.cleanup()
+
+    @property
+    def auth_headers(self):
+        return {"Authorization": f"Bearer {self.token}"}
+
+    def _message(self, message_id):
+        with self.app.app_context():
+            with db.session() as db_session:
+                return db_session.query(Email).get(message_id)
+
+    # --- Validation -----------------------------------------------------------
+
+    def test_create_link_requires_auth(self):
+        """Unauthenticated requests are rejected with 401 UNAUTHORIZED."""
+        response = self.client.post("/api/links", json={"url": "https://example.com/a"})
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.get_json().get("code"), "UNAUTHORIZED")
+
+    def test_create_link_rejects_non_json(self):
+        """Non-JSON bodies are rejected with 400."""
+        response = self.client.post(
+            "/api/links",
+            data="not json",
+            content_type="text/plain",
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_link_requires_url(self):
+        """A missing URL yields 422."""
+        response = self.client.post("/api/links", json={}, headers=self.auth_headers)
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_link_rejects_invalid_url(self):
+        """Non-http(s) or malformed URLs yield 422."""
+        for bad in ("ftp://example.com/file", "not-a-url", "https://"):
+            response = self.client.post("/api/links", json={"url": bad}, headers=self.auth_headers)
+            self.assertEqual(response.status_code, 422, bad)
+
+    def test_create_link_rejects_draft(self):
+        """Atacama has no drafts; draft=true is rejected with a clear message."""
+        response = self.client.post(
+            "/api/links",
+            json={"url": "https://example.com/a", "draft": True},
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, 422)
+        self.assertIn("draft", response.get_json()["message"].lower())
+
+    def test_create_link_rejects_unknown_channel(self):
+        """An unknown topic/channel yields 422."""
+        response = self.client.post(
+            "/api/links",
+            json={"url": "https://example.com/a", "topic": "no-such-channel"},
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_link_rejects_overlong_fields(self):
+        """Field limits mirror the newslettr backend."""
+        base = {"url": "https://example.com/a"}
+        for overrides in (
+            {"url": "https://example.com/" + "a" * 2000},
+            {"title": "t" * 201},
+            {"quote": "q" * 2001},
+            {"comment": "c" * 2001},
+        ):
+            response = self.client.post(
+                "/api/links", json={**base, **overrides}, headers=self.auth_headers
+            )
+            self.assertEqual(response.status_code, 422, overrides)
+
+    # --- Creation -------------------------------------------------------------
+
+    def test_create_link_bare_share(self):
+        """A bare URL share succeeds: title falls back to the host, channel to default."""
+        response = self.client.post(
+            "/api/links",
+            json={"url": "https://example.com/article"},
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, 201)
+        data = response.get_json()
+        self.assertEqual(data["title"], "example.com")
+        self.assertEqual(data["domain"], "example.com")
+        self.assertEqual(data["url"], "https://example.com/article")
+        self.assertFalse(data["is_draft"])
+        self.assertEqual(data["topic"]["id"], "private")  # default_channel
+
+        with self.app.app_context():
+            with db.session() as db_session:
+                message = db_session.query(Email).get(data["id"])
+                self.assertIsNotNone(message)
+                self.assertEqual(message.subject, "example.com")
+                self.assertEqual(message.channel, "private")
+                self.assertEqual(message.author.email, self.user_email)
+                self.assertIn("https://example.com/article", message.content)
+                self.assertTrue(message.processed_content)
+
+    def test_create_link_full_share(self):
+        """Title, quote, comment, and topic all land in the saved message."""
+        response = self.client.post(
+            "/api/links",
+            json={
+                "url": "https://example.com/article",
+                "title": "Great read",
+                "quote": "A pulled excerpt.",
+                "comment": "Why it matters.",
+                "topic": "misc",
+            },
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, 201)
+        data = response.get_json()
+        self.assertEqual(data["title"], "Great read")
+        self.assertEqual(data["topic"]["id"], "misc")
+        self.assertTrue(data["message_url"].endswith(f"/messages/{data['id']}"))
+
+        message = self._message(data["id"])
+        self.assertEqual(message.subject, "Great read")
+        self.assertEqual(message.channel, "misc")
+        self.assertIn("Why it matters.", message.content)
+        self.assertIn("<quote> A pulled excerpt.", message.content)
+        self.assertIn("https://example.com/article", message.content)
+        # The comment (the sharer's voice) leads the composed message.
+        self.assertTrue(message.content.startswith("Why it matters."))
+
+    def test_create_link_accepts_channel_alias(self):
+        """The atacama-style `channel` key is accepted as an alias for `topic`."""
+        response = self.client.post(
+            "/api/links",
+            json={"url": "https://example.com/a", "channel": "misc"},
+            headers=self.auth_headers,
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(self._message(response.get_json()["id"]).channel, "misc")
+
+    def test_config_advertises_links_capability(self):
+        """GET /api/atacama-config advertises links so clients can discover support."""
+        response = self.client.get("/api/atacama-config")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.get_json()["capabilities"]["links"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The atacama-ios Share Extension posts shared URLs to `POST /api/links`, which was only implemented on the newslettr backend. This adds the endpoint to atacama, mirroring newslettr's contract so the one extension works against either backend.

- **`POST /api/links`** (`src/blog/blueprints/api.py`): only `url` is required — `title` falls back to the URL's host and the channel to the configured default; accepts `topic` with `channel` as an alias; enforces the same field limits as newslettr (url ≤ 2000, title ≤ 200, quote/comment ≤ 2000); 422 on an unknown channel. Atacama has no separate link model, so the share is saved as a regular message through the shared `create_email_message` pipeline: the comment leads, the quote renders as a `<quote>` block, and the URL sits on its own line so it's auto-linked and archived.
- **Drafts**: atacama has no unpublished drafts, so `"draft": true` is rejected with a 422 whose message tells the user to turn off "Save as draft" (surfaced inline in the extension) rather than silently publishing.
- **`GET /api/atacama-config`** now advertises `"links": true`.
- **Bug fix**: `save_quotes` ran a `Quote` lookup mid-render, and the query-invoked autoflush tried to INSERT the pending `Email` before its NOT NULL `processed_content` was set — any message containing a `<quote>` tag (including via the web form) would fail. The lookup is now wrapped in `no_autoflush`.

## Testing

- 11 new tests in `src/tests/blog/test_links_api.py` covering auth, validation (URL/field limits/unknown channel/draft rejection), bare and full shares, the `channel` alias, and the capability flag.
- `black`, `python3 precommit.py`, and the blog/quick/aml_parser test categories pass. (`test_content_serving`, `test_template`, and a few `models`/`common` tests segfault/fail identically on the untouched tree — pre-existing environment issues.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K72uFR7BRMBekKPijjbFr2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K72uFR7BRMBekKPijjbFr2)_